### PR TITLE
Close the batching receiver on closing the client

### DIFF
--- a/lib/queueClient.ts
+++ b/lib/queueClient.ts
@@ -58,9 +58,13 @@ export class QueueClient extends Client {
         if (this._context.sender) {
           await this._context.sender.close();
         }
-        // Close the receiver.
+        // Close the streaming receiver.
         if (this._context.streamingReceiver) {
           await this._context.streamingReceiver.close();
+        }
+        // Close the batching receiver.
+        if (this._context.batchingReceiver) {
+          await this._context.batchingReceiver.close();
         }
         log.qClient("Closed the client '%s'.", this.id);
       }

--- a/lib/subscriptionClient.ts
+++ b/lib/subscriptionClient.ts
@@ -62,9 +62,13 @@ export class SubscriptionClient extends Client {
   async close(): Promise<void> {
     try {
       if (this._context.namespace.connection && this._context.namespace.connection.isOpen()) {
-        // Close the receiver.
+        // Close the streaming receiver.
         if (this._context.streamingReceiver) {
           await this._context.streamingReceiver.close();
+        }
+        // Close the batching receiver.
+        if (this._context.batchingReceiver) {
+          await this._context.batchingReceiver.close();
         }
         log.subscriptionClient("Closed the subscription client '%s'.", this.id);
       }


### PR DESCRIPTION
## Description

Close the batching receiver in the queue client and the subscription client when the client is closed.
Fixes bug #25
