### PR TITLE
Allow multiple recieveBatch calls on queueClient

### DIFF
--- a/lib/core/batchingReceiver.ts
+++ b/lib/core/batchingReceiver.ts
@@ -67,7 +67,7 @@ export class BatchingReceiver extends MessageReceiver {
     }
 
     const brokeredMessages: ServiceBusMessage[] = [];
-    let timeOver = false;
+
     this.isReceivingMessages = true;
     return new Promise<ServiceBusMessage[]>((resolve, reject) => {
       let onReceiveMessage: OnAmqpEventAsPromise;
@@ -84,7 +84,7 @@ export class BatchingReceiver extends MessageReceiver {
         this._receiver!.addCredit(0);
       };
       // Final action to be performed after maxMessageCount is reached or the maxWaitTime is over.
-      const finalAction = (timeOver: boolean, data?: ServiceBusMessage) => {
+      const finalAction = () => {
         if (maxMessageWaitTimer) {
           clearTimeout(maxMessageWaitTimer);
         }
@@ -93,12 +93,8 @@ export class BatchingReceiver extends MessageReceiver {
           this._receiver.removeListener(ReceiverEvents.receiverError, onReceiveError);
           this._receiver.removeListener(ReceiverEvents.message, onReceiveMessage);
         }
-        if (!data) {
-          data = brokeredMessages.length ? brokeredMessages[brokeredMessages.length - 1] : undefined;
-        }
-        if (!timeOver) {
-          clearTimeout(waitTimer);
-        }
+
+        clearTimeout(waitTimer);
         resetCreditWindow();
         this.isReceivingMessages = false;
         log.batching("[%s] Resolving the promise with received list of messages: %O.",
@@ -112,16 +108,15 @@ export class BatchingReceiver extends MessageReceiver {
           const msg = `BatchingReceiver '${this.name}' did not receive any messages in the last ` +
             `${maxMessageWaitTimeoutInSeconds} seconds. Hence ending this batch receive operation.`;
           log.error("[%s] %s", this._context.namespace.connectionId, msg);
-          finalAction(true);
+          finalAction();
         }, maxMessageWaitTimeoutInSeconds! * 1000);
       };
 
       // Action to be performed after the max wait time is over.
       actionAfterWaitTimeout = () => {
-        timeOver = true;
         log.batching("[%s] Batching Receiver '%s'  max wait time in seconds %d over.",
           this._context.namespace.connectionId, this.name, maxWaitTimeInSeconds);
-        return finalAction(timeOver);
+        return finalAction();
       };
 
       // Action to be performed on the "message" event.
@@ -129,11 +124,11 @@ export class BatchingReceiver extends MessageReceiver {
         resetTimerOnNewMessageReceived();
         const data: ServiceBusMessage = new ServiceBusMessage(this._context,
           context.message!, context.delivery!);
-        if (brokeredMessages.length <= maxMessageCount) {
+        if (brokeredMessages.length < maxMessageCount) {
           brokeredMessages.push(data);
         }
         if (brokeredMessages.length === maxMessageCount) {
-          finalAction(timeOver, data);
+          finalAction();
         }
       };
 

--- a/lib/queueClient.ts
+++ b/lib/queueClient.ts
@@ -131,18 +131,7 @@ export class QueueClient extends Client {
    * receiving more messages.
    */
   receive(onMessage: OnMessage, onError: OnError, options?: MessageHandlerOptions): ReceiveHandler {
-    if (!this._context.streamingReceiver || !this._context.streamingReceiver.isOpen()) {
-      if (!options) options = {};
-      const rcvOptions: ReceiveOptions = {
-        maxConcurrentCalls: options.maxConcurrentCalls || 1,
-        receiveMode: this.receiveMode,
-        autoComplete: options.autoComplete,
-        maxAutoRenewDurationInSeconds: options.maxAutoRenewDurationInSeconds
-      };
-      const sReceiver = StreamingReceiver.create(this._context, rcvOptions);
-      this._context.streamingReceiver = sReceiver;
-      return sReceiver.receive(onMessage, onError);
-    } else {
+    if (this._context.streamingReceiver && this._context.streamingReceiver.isOpen()) {
       const rcvr = this._context.streamingReceiver;
       const msg = `A "${rcvr.receiverType}" receiver with id "${rcvr.name}" has already been ` +
         `created for the Queue "${this.name}". Another receive() call cannot be made while the ` +
@@ -150,6 +139,17 @@ export class QueueClient extends Client {
         `"receiveHandler.stop()".`;
       throw new Error(msg);
     }
+
+    if (!options) options = {};
+    const rcvOptions: ReceiveOptions = {
+      maxConcurrentCalls: options.maxConcurrentCalls || 1,
+      receiveMode: this.receiveMode,
+      autoComplete: options.autoComplete,
+      maxAutoRenewDurationInSeconds: options.maxAutoRenewDurationInSeconds
+    };
+    const sReceiver = StreamingReceiver.create(this._context, rcvOptions);
+    this._context.streamingReceiver = sReceiver;
+    return sReceiver.receive(onMessage, onError);
   }
 
   /**
@@ -168,31 +168,34 @@ export class QueueClient extends Client {
   async receiveBatch(maxMessageCount: number,
     maxWaitTimeInSeconds?: number,
     maxMessageWaitTimeoutInSeconds?: number): Promise<ServiceBusMessage[]> {
-    if (!this._context.batchingReceiver ||
-      (this._context.batchingReceiver && !this._context.batchingReceiver.isOpen()) ||
-      (this._context.batchingReceiver && !this._context.batchingReceiver.isReceivingMessages)) {
-      const options: ReceiveOptions = {
-        maxConcurrentCalls: 0,
-        receiveMode: this.receiveMode
-      };
-      const bReceiver: BatchingReceiver = BatchingReceiver.create(this._context, options);
-      this._context.batchingReceiver = bReceiver;
-      try {
-        return await bReceiver.receive(maxMessageCount, maxWaitTimeInSeconds,
-          maxMessageWaitTimeoutInSeconds);
-      } catch (err) {
-        log.error("[%s] Receiver '%s', an error occurred while receiving %d messages for %d " +
-          "max time:\n %O", this._context.namespace.connectionId, bReceiver.name, maxMessageCount,
-          maxWaitTimeInSeconds, err);
-        throw err;
-      }
-    } else {
-      const rcvr = this._context.batchingReceiver;
-      const msg = `A "${rcvr.receiverType}" receiver with id "${rcvr.name}" has already been ` +
+
+    let bReceiver = this._context.batchingReceiver;
+    if (bReceiver
+      && bReceiver.isOpen()
+      && bReceiver.isReceivingMessages) {
+      const msg = `A "${bReceiver.receiverType}" receiver with id "${bReceiver.name}" has already been ` +
         `created for the Queue "${this.name}". Another receiveBatch() call cannot be made while the ` +
         `previous one is active. Please wait for the previous receiveBatch() to complete and ` +
         `then call receiveBatch() again.`;
       throw new Error(msg);
+    }
+
+    if (!bReceiver || !bReceiver.isOpen()) {
+      const options: ReceiveOptions = {
+        maxConcurrentCalls: 0,
+        receiveMode: this.receiveMode
+      };
+      this._context.batchingReceiver = bReceiver = BatchingReceiver.create(this._context, options);
+    }
+
+    try {
+      return await bReceiver.receive(maxMessageCount, maxWaitTimeInSeconds,
+        maxMessageWaitTimeoutInSeconds);
+    } catch (err) {
+      log.error("[%s] Receiver '%s', an error occurred while receiving %d messages for %d " +
+        "max time:\n %O", this._context.namespace.connectionId, bReceiver.name, maxMessageCount,
+        maxWaitTimeInSeconds, err);
+      throw err;
     }
   }
 


### PR DESCRIPTION
This PR address the issue #31 

- Updated `receiveBatch` call on the queueClient to re-use existing receiver if it is not currently receiving any messages
- Removed dead code from `finalAction()`.

When working on this, I realized that the initial `onReceiveMessage` handler which is used in the `_init()` call never gets disposed even after calling `this._receiver.removeListener(ReceiverEvents.message, onReceiveMessage);`

Due to this every call to `receiveBatch` will end up calling 2 instances of the `onReceiveMessage`.

@amarzavery Any thoughts on this?

  