### PR TITLE
Ensure listeners are removed when receivers are re-used

### DIFF
--- a/lib/core/batchingReceiver.ts
+++ b/lib/core/batchingReceiver.ts
@@ -76,6 +76,11 @@ export class BatchingReceiver extends MessageReceiver {
 
     this.isReceivingMessages = true;
     return new Promise<ServiceBusMessage[]>((resolve, reject) => {
+      let onReceiveMessage: OnAmqpEventAsPromise;
+      let onSessionClose: OnAmqpEventAsPromise;
+      let onReceiveClose: OnAmqpEventAsPromise;
+      let onReceiveError: OnAmqpEvent;
+      let onSessionError: OnAmqpEvent;
       let waitTimer: any;
       let maxMessageWaitTimer: any;
       const resetCreditWindow = () => {
@@ -127,7 +132,7 @@ export class BatchingReceiver extends MessageReceiver {
       };
 
       // Action to be performed on the "message" event.
-      const onReceiveMessage: OnAmqpEventAsPromise = async (context: EventContext) => {
+      onReceiveMessage = async (context: EventContext) => {
         try {
           resetTimerOnNewMessageReceived();
           const data: ServiceBusMessage = new ServiceBusMessage(
@@ -152,7 +157,7 @@ export class BatchingReceiver extends MessageReceiver {
       };
 
       // Action to be taken when an error is received.
-      const onReceiveError: OnAmqpEvent = (context: EventContext) => {
+      onReceiveError = (context: EventContext) => {
         this.isReceivingMessages = false;
         const receiver = this._receiver || context.receiver!;
         receiver.removeListener(ReceiverEvents.receiverError, onReceiveError);
@@ -179,7 +184,7 @@ export class BatchingReceiver extends MessageReceiver {
         reject(error);
       };
 
-      const onReceiveClose: OnAmqpEventAsPromise = async (context: EventContext) => {
+      onReceiveClose = async (context: EventContext) => {
         try {
           this.isReceivingMessages = false;
           const receiverError = context.receiver && context.receiver.error;
@@ -200,7 +205,7 @@ export class BatchingReceiver extends MessageReceiver {
         }
       };
 
-      const onSessionClose: OnAmqpEventAsPromise = async (context: EventContext) => {
+      onSessionClose = async (context: EventContext) => {
         try {
           this.isReceivingMessages = false;
           const sessionError = context.session && context.session.error;
@@ -222,7 +227,7 @@ export class BatchingReceiver extends MessageReceiver {
         }
       };
 
-      const onSessionError: OnAmqpEvent = (context: EventContext) => {
+      onSessionError = (context: EventContext) => {
         this.isReceivingMessages = false;
         const receiver = this._receiver || context.receiver!;
         receiver.removeListener(ReceiverEvents.receiverError, onReceiveError);

--- a/lib/core/messageReceiver.ts
+++ b/lib/core/messageReceiver.ts
@@ -26,7 +26,6 @@ interface CreateReceiverOptions {
   onError: OnAmqpEvent;
   onSettled: OnAmqpEvent;
   onSessionError: OnAmqpEvent;
-  newName?: boolean;
 }
 
 /**
@@ -543,17 +542,9 @@ export class MessageReceiver extends LinkEntity {
           connectionId, this.name, this.address, state);
       }
       if (shouldReopen) {
-        const rcvrOptions: CreateReceiverOptions = {
-          onMessage: (context: EventContext) => this._onAmqpMessage(context).catch(() => { /* */ }),
-          onClose: (context: EventContext) => this._onAmqpClose(context).catch(() => { /* */ }),
-          onSessionClose: (context: EventContext) => this._onSessionClose(context).catch(() => { /* */ }),
-          onError: this._onAmqpError,
-          onSessionError: this._onSessionError,
-          onSettled: this._onSettled,
-          newName: true // provide a new name to the link while re-connecting it. This ensures that
-          // the service does not send an error stating that the link is still open.
-        };
-        const options: ReceiverOptions = this._createReceiverOptions(rcvrOptions);
+        // provide a new name to the link while re-connecting it. This ensures that
+        // the service does not send an error stating that the link is still open.
+        const options: ReceiverOptions = this._createReceiverOptions(true);
         // shall retry forever at an interval of 15 seconds if the error is a retryable error
         // else bail out when the error is not retryable or the oepration succeeds.
         const config: RetryConfig<void> = {
@@ -667,14 +658,7 @@ export class MessageReceiver extends LinkEntity {
         this.isConnecting = true;
         await this._negotiateClaim();
         if (!options) {
-          options = this._createReceiverOptions({
-            onMessage: (context: EventContext) => this._onAmqpMessage(context).catch(() => { /* */ }),
-            onClose: (context: EventContext) => this._onAmqpClose(context).catch(() => { /* */ }),
-            onSessionClose: (context: EventContext) => this._onSessionClose(context).catch(() => { /* */ }),
-            onError: this._onAmqpError,
-            onSessionError: this._onSessionError,
-            onSettled: this._onSettled
-          });
+          options = this._createReceiverOptions();
         }
         log.error("[%s] Trying to create receiver '%s' with options %O",
           connectionId, this.name, options);
@@ -713,10 +697,19 @@ export class MessageReceiver extends LinkEntity {
    * Creates the options that need to be specified while creating an AMQP receiver link.
    * @ignore
    */
-  protected _createReceiverOptions(options: CreateReceiverOptions): ReceiverOptions {
-    if (options.newName) this.name = getUniqueName(this._context.entityPath);
+  protected _createReceiverOptions(useNewName?: boolean, options?: CreateReceiverOptions): ReceiverOptions {
+    if (!options) {
+      options = {
+        onMessage: (context: EventContext) => this._onAmqpMessage(context).catch(() => { /* */ }),
+        onClose: (context: EventContext) => this._onAmqpClose(context).catch(() => { /* */ }),
+        onSessionClose: (context: EventContext) => this._onSessionClose(context).catch(() => { /* */ }),
+        onError: this._onAmqpError,
+        onSessionError: this._onSessionError,
+        onSettled: this._onSettled
+      }
+    }
     const rcvrOptions: ReceiverOptions = {
-      name: this.name,
+      name: useNewName ? getUniqueName(this._context.entityPath) : this.name,
       autoaccept: false,
       // receiveAndDelete -> first(0), peekLock -> second (1)
       rcv_settle_mode: this.receiveMode === ReceiveMode.receiveAndDelete ? 0 : 1,
@@ -726,12 +719,7 @@ export class MessageReceiver extends LinkEntity {
         address: this.address
       },
       credit_window: this.maxConcurrentCalls,
-      onMessage: (context) => (options.onMessage || this._onAmqpMessage)(context).catch(() => { /* */ }),
-      onClose: (context) => (options.onClose || this._onAmqpClose)(context).catch(() => { /* */ }),
-      onSessionClose: (context) => (options.onSessionClose || this._onSessionClose)(context).catch(() => { /* */ }),
-      onError: options.onError || this._onAmqpError,
-      onSessionError: options.onSessionError || this._onSessionError,
-      onSettled: options.onSettled || this._onSettled
+      ...options
     };
     return rcvrOptions;
   }


### PR DESCRIPTION
Since the `onReceiveMessage` of the batchingReciever gets the `.catch()` attached to it before being set as a handler on the receiver, the `removeListener` on it doesnt work which is important when we re-use the subsequent `receiveBatch` calls to work.

This PR covers
- move the try/catch to where the handlers are defined
- avoid passing defaults to `_createReceiverOptions()`