### PR TITLE
Retry connecting only for retryable errors

### DIFF
--- a/lib/connectionContext.ts
+++ b/lib/connectionContext.ts
@@ -106,7 +106,7 @@ export namespace ConnectionContext {
             connectionContext.connection.id,
             client.id
           );
-          client.detached().catch((err) => {
+          client.detached(connectionError || contextError).catch((err) => {
             log.error(
               "[%s] An error occurred while reconnecting the sender '%s': %O.",
               connectionContext.connection.id,


### PR DESCRIPTION
Calling a `receive` or `receiveBatch` on a non existing namespace returns a non retryable error.
But, we continue to try to re-connect regardless.

This PR passes the connection related errors to the detached() call on the clients, so that the receivers are aware of the error and its non retryability.