### PR TITLE
Add api-extractor for dts rollups and API reviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ lib-cov
 # Coverage directory used by tools like istanbul
 coverage
 
+# API Extractor temp files
+temp/*
+
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/api-extractor.schema.json",
+  "compiler": {
+    "configType": "tsconfig",
+    "rootFolder": "."
+  },
+  "apiReviewFile": {
+    "enabled": true,
+    "apiReviewFolder": "./etc"
+  },
+  "validationRules": {
+    "missingReleaseTags": "allow"
+  },
+  "project": {
+    "entryPointSourceFile": "typings/lib/index.d.ts"
+  },
+  "dtsRollup": {
+    "enabled": true,
+    "mainDtsRollupPath": "../typings/lib/index-rollup.d.ts"
+  }
+}

--- a/etc/service-bus.api.ts
+++ b/etc/service-bus.api.ts
@@ -1,0 +1,411 @@
+// @public
+interface AmqpError {
+  condition?: string;
+  description?: string;
+  info?: any;
+  value?: any[];
+}
+
+// @public
+interface ConnectionConfig {
+}
+
+// @public
+interface CorrelationFilter {
+  contentType?: string;
+  correlationId?: string;
+  label?: string;
+  messageId?: string;
+  replyTo?: string;
+  replyToSessionId?: string;
+  sessionId?: string;
+  to?: string;
+  userProperties?: any;
+}
+
+// @public
+interface DataTransformer {
+  decode: (body: any) => any;
+  encode: (body: any) => any;
+}
+
+// @public
+interface DeadLetterOptions {
+  deadLetterErrorDescription: string;
+  deadletterReason: string;
+}
+
+// @public
+class DefaultDataTransformer implements DataTransformer {
+  decode(body: any): any;
+  encode(body: any): any;
+}
+
+// @public
+export function delay<T>(t: number, value?: T): Promise<T>;
+
+// @public (undocumented)
+interface Delivery {
+  // (undocumented)
+  accept(): void;
+  // (undocumented)
+  readonly format: number;
+  // (undocumented)
+  readonly id: number;
+  // (undocumented)
+  readonly link: Sender | Receiver;
+  // (undocumented)
+  modified(params?: ReleaseParameters): void;
+  // (undocumented)
+  reject(error?: AmqpError): void;
+  // (undocumented)
+  release(params?: ReleaseParameters): void;
+  // (undocumented)
+  readonly remote_settled: boolean;
+  // (undocumented)
+  readonly remote_state?: DeliveryOutcome;
+  // (undocumented)
+  readonly sent: boolean;
+  // (undocumented)
+  readonly settled: boolean;
+  // (undocumented)
+  readonly state?: DeliveryOutcome;
+  // (undocumented)
+  readonly tag: Buffer | string;
+  // (undocumented)
+  update(settled: boolean, state?: any): void;
+}
+
+// @public
+interface Dictionary<T> {
+  // (undocumented)
+  [key: string]: T;
+}
+
+// @public (undocumented)
+interface MessageHandlerOptions {
+  autoComplete?: boolean;
+  maxAutoRenewDurationInSeconds?: number;
+  maxConcurrentCalls?: number;
+}
+
+// @public
+interface MessageHeader {
+  delivery_count?: number;
+  durable?: boolean;
+  first_acquirer?: boolean;
+  priority?: number;
+  ttl?: number;
+}
+
+// @public
+interface MessageProperties {
+  absolute_expiry_time?: number;
+  content_encoding?: string;
+  content_type?: string;
+  correlation_id?: string | number | Buffer;
+  creation_time?: number;
+  group_id?: string;
+  group_sequence?: number;
+  message_id?: string | number | Buffer;
+  reply_to?: string;
+  reply_to_group_id?: string;
+  subject?: string;
+  to?: string;
+  user_id?: string;
+}
+
+// @public
+class MessageSession extends LinkEntity {
+  // WARNING: The type "ClientEntityContext" needs to be exported by the package (e.g. added to index.ts)
+  // WARNING: The type "MessageSessionOptions" needs to be exported by the package (e.g. added to index.ts)
+  constructor(context: ClientEntityContext, options?: MessageSessionOptions);
+  autoComplete: boolean;
+  autoRenewLock: boolean;
+  close(): Promise<void>;
+  // WARNING: The type "ClientEntityContext" needs to be exported by the package (e.g. added to index.ts)
+  // WARNING: The type "MessageSessionOptions" needs to be exported by the package (e.g. added to index.ts)
+  static create(context: ClientEntityContext, options?: MessageSessionOptions): Promise<MessageSession>;
+  getState(): Promise<void>;
+  isOpen(): boolean;
+  maxAutoRenewDurationInSeconds: number;
+  maxConcurrentCallsPerSession?: number;
+  maxConcurrentSessions?: number;
+  maxMessageWaitTimeoutInSeconds: number;
+  peek(messageCount?: number): Promise<ReceivedMessageInfo[]>;
+  peekBySequenceNumber(fromSequenceNumber: Long, messageCount?: number): Promise<ReceivedMessageInfo[]>;
+  // WARNING: The type "SessionHandlerOptions" needs to be exported by the package (e.g. added to index.ts)
+  receive(onSessionMessage: OnSessionMessage, onError: OnError, options?: SessionHandlerOptions): void;
+  receiveBatch(maxMessageCount: number, maxWaitTimeInSeconds?: number): Promise<ServiceBusMessage[]>;
+  receiveDeferredMessage(sequenceNumber: Long): Promise<ServiceBusMessage | undefined>;
+  receiveDeferredMessages(sequenceNumbers: Long[]): Promise<ServiceBusMessage[]>;
+  receiveMode: ReceiveMode;
+  renewLock(): Promise<Date>;
+  sessionId?: string;
+  sessionLockedUntilUtc?: Date;
+  setState(state: any): Promise<void>;
+  // WARNING: The type "DispositionType" needs to be exported by the package (e.g. added to index.ts)
+  // WARNING: The type "DispositionOptions" needs to be exported by the package (e.g. added to index.ts)
+  settleMessage(message: ServiceBusMessage, operation: DispositionType, options?: DispositionOptions): Promise<any>;
+}
+
+// @public
+class MessagingError extends Error {
+  constructor(message: string);
+  condition?: string;
+  info?: any;
+  name: string;
+  retryable: boolean;
+  translated: boolean;
+}
+
+// @public
+class Namespace {
+  constructor(config: ConnectionConfig, options?: NamespaceOptions);
+  close(): Promise<any>;
+  // WARNING: The type "NamespaceOptionsBase" needs to be exported by the package (e.g. added to index.ts)
+  static createFromAadTokenCredentials(host: string, credentials: ApplicationTokenCredentials | UserTokenCredentials | DeviceTokenCredentials | MSITokenCredentials, options?: NamespaceOptions): Namespace;
+  static createFromConnectionString(connectionString: string, options?: NamespaceOptions): Namespace;
+  // WARNING: The type "NamespaceOptionsBase" needs to be exported by the package (e.g. added to index.ts)
+  // WARNING: The type "NamespaceOptionsBase" needs to be exported by the package (e.g. added to index.ts)
+  static createFromTokenProvider(host: string, tokenProvider: TokenProvider, options?: NamespaceOptionsBase): Namespace;
+  createQueueClient(queueName: string, options?: QueueClientOptions): QueueClient;
+  createSubscriptionClient(topicName: string, subscriptionName: string, options?: SubscriptionClientOptions): SubscriptionClient;
+  createTopicClient(topicName: string): TopicClient;
+  // (undocumented)
+  static getDeadLetterQueuePathForQueue(queueName: string): string;
+  name: string;
+}
+
+// @public
+interface NamespaceOptions extends NamespaceOptionsBase {
+  tokenProvider?: TokenProvider;
+}
+
+// @public
+export function parseConnectionString<T>(connectionString: string): ParsedOutput<T>;
+
+// @public (undocumented)
+class QueueClient extends Client {
+  // WARNING: The type "ConnectionContext" needs to be exported by the package (e.g. added to index.ts)
+  constructor(name: string, context: ConnectionContext, options?: QueueClientOptions);
+  // WARNING: The type "AcceptSessionOptions" needs to be exported by the package (e.g. added to index.ts)
+  // (undocumented)
+  acceptSession(options?: AcceptSessionOptions): Promise<MessageSession>;
+  cancelScheduledMessage(sequenceNumber: Long): Promise<void>;
+  cancelScheduledMessages(sequenceNumbers: Long[]): Promise<void>;
+  close(): Promise<any>;
+  // WARNING: The type "ListSessionsResponse" needs to be exported by the package (e.g. added to index.ts)
+  listMessageSessions(skip: number, top: number, lastUpdatedTime?: Date): Promise<ListSessionsResponse>;
+  peek(messageCount?: number): Promise<ReceivedMessageInfo[]>;
+  peekBySequenceNumber(fromSequenceNumber: Long, messageCount?: number): Promise<ReceivedMessageInfo[]>;
+  receive(onMessage: OnMessage, onError: OnError, options?: MessageHandlerOptions): ReceiveHandler;
+  receiveBatch(maxMessageCount: number, maxWaitTimeInSeconds?: number, maxMessageWaitTimeoutInSeconds?: number): Promise<ServiceBusMessage[]>;
+  receiveDeferredMessage(sequenceNumber: Long): Promise<ServiceBusMessage | undefined>;
+  receiveDeferredMessages(sequenceNumbers: Long[]): Promise<ServiceBusMessage[]>;
+  // WARNING: The type "SessionHandlerOptions" needs to be exported by the package (e.g. added to index.ts)
+  receiveMessgesFromSessions(onSessionMessage: OnSessionMessage, onError: OnError, options?: SessionHandlerOptions): Promise<void>;
+  receiveMode: ReceiveMode;
+  renewLock(lockTokenOrMessage: string | ServiceBusMessage): Promise<Date>;
+  scheduleMessage(message: SendableMessageInfo, scheduledEnqueueTimeUtc: Date): Promise<Long>;
+  scheduleMessages(messages: ScheduleMessage[]): Promise<Long[]>;
+  send(data: SendableMessageInfo): Promise<Delivery>;
+  sendBatch(datas: SendableMessageInfo[]): Promise<Delivery>;
+}
+
+// @public
+interface QueueClientOptions {
+  receiveMode?: ReceiveMode;
+}
+
+// @public
+interface ReceivedMessageInfo {
+}
+
+// @public
+class ReceiveHandler {
+  // WARNING: The type "MessageReceiver" needs to be exported by the package (e.g. added to index.ts)
+  // WARNING: The type "MessageReceiver" needs to be exported by the package (e.g. added to index.ts)
+  constructor(receiver: MessageReceiver);
+  readonly address: string | undefined;
+  readonly autoComplete: boolean;
+  readonly isReceiverOpen: boolean;
+  readonly name: string;
+  readonly receiveMode: ReceiveMode;
+  stop(): Promise<void>;
+}
+
+// @public
+enum ReceiveMode {
+  peekLock = 1,
+  receiveAndDelete = 2
+}
+
+// @public
+interface RuleDescription {
+  action?: SQLExpression;
+  filter?: SQLExpression | CorrelationFilter;
+  name: string;
+}
+
+// @public
+interface ScheduleMessage {
+  message: SendableMessageInfo;
+  scheduledEnqueueTimeUtc: Date;
+}
+
+// @public (undocumented)
+interface SendableMessageInfo {
+}
+
+// @public
+interface ServiceBusConnectionStringModel {
+  // (undocumented)
+  [x: string]: any;
+  // (undocumented)
+  Endpoint: string;
+  // (undocumented)
+  EntityPath?: string;
+  // (undocumented)
+  SharedAccessKey: string;
+  // (undocumented)
+  SharedAccessKeyName: string;
+}
+
+// @public
+interface ServiceBusDeliveryAnnotations extends DeliveryAnnotations {
+  [x: string]: any;
+  last_enqueued_offset?: string;
+  last_enqueued_sequence_number?: number;
+  last_enqueued_time_utc?: number;
+  runtime_info_retrieval_time_utc?: number;
+}
+
+// @public
+class ServiceBusMessage implements ReceivedMessage {
+  // WARNING: The type "ClientEntityContext" needs to be exported by the package (e.g. added to index.ts)
+  constructor(context: ClientEntityContext, msg: AmqpMessage, delivery: Delivery);
+  readonly _amqpMessage: AmqpMessage;
+  abandon(propertiesToModify?: Dictionary<any>): Promise<void>;
+  body: any;
+  clone(): SendableMessageInfo;
+  complete(): Promise<void>;
+  contentType?: string;
+  correlationId?: string | number | Buffer;
+  deadLetter(options?: DeadLetterOptions): Promise<void>;
+  readonly deadLetterSource?: string;
+  defer(propertiesToModify?: Dictionary<any>): Promise<void>;
+  readonly delivery: Delivery;
+  readonly deliveryCount?: number;
+  readonly enqueuedSequenceNumber?: number;
+  readonly enqueuedTimeUtc?: Date;
+  readonly expiresAtUtc?: Date;
+  label?: string;
+  lockedUntilUtc?: Date;
+  readonly lockToken?: string;
+  messageId?: string | number | Buffer;
+  partitionKey?: string;
+  replyTo?: string;
+  replyToSessionId?: string;
+  scheduledEnqueueTimeUtc?: Date;
+  readonly sequenceNumber?: Long;
+  sessionId?: string;
+  timeToLive?: number;
+  to?: string;
+  userProperties?: Dictionary<any>;
+  viaPartitionKey?: string;
+}
+
+// @public
+interface ServiceBusMessageAnnotations extends MessageAnnotations {
+  // WARNING: The name "x-opt-enqueued-time" contains unsupported characters; API names should use only letters, numbers, and underscores
+  x-opt-enqueued-time?: number;
+  // WARNING: The name "x-opt-locked-until" contains unsupported characters; API names should use only letters, numbers, and underscores
+  x-opt-locked-until?: Date | number;
+  // WARNING: The name "x-opt-offset" contains unsupported characters; API names should use only letters, numbers, and underscores
+  x-opt-offset?: string;
+  // WARNING: The name "x-opt-partition-key" contains unsupported characters; API names should use only letters, numbers, and underscores
+  x-opt-partition-key?: string | null;
+  // WARNING: The name "x-opt-sequence-number" contains unsupported characters; API names should use only letters, numbers, and underscores
+  x-opt-sequence-number?: number;
+}
+
+// @public
+interface SQLExpression {
+  expression: string;
+}
+
+// @public (undocumented)
+class SubscriptionClient extends Client {
+  // WARNING: The type "ConnectionContext" needs to be exported by the package (e.g. added to index.ts)
+  constructor(topicPath: string, subscriptionName: string, context: ConnectionContext, options?: SubscriptionClientOptions);
+  addRule(ruleName: string, filter: boolean | string | CorrelationFilter, sqlRuleActionExpression?: string): Promise<void>;
+  close(): Promise<void>;
+  readonly defaultRuleName: string;
+  getRules(): Promise<RuleDescription[]>;
+  peek(messageCount?: number): Promise<ReceivedMessageInfo[]>;
+  peekBySequenceNumber(fromSequenceNumber: Long, messageCount?: number): Promise<ReceivedMessageInfo[]>;
+  receive(onMessage: OnMessage, onError: OnError, options?: MessageHandlerOptions): ReceiveHandler;
+  receiveBatch(maxMessageCount: number, maxWaitTimeInSeconds?: number, maxMessageWaitTimeoutInSeconds?: number): Promise<ServiceBusMessage[]>;
+  receiveDeferredMessage(sequenceNumber: Long): Promise<ServiceBusMessage | undefined>;
+  receiveDeferredMessages(sequenceNumbers: Long[]): Promise<ReceivedMessageInfo[]>;
+  receiveMode: ReceiveMode;
+  removeRule(ruleName: string): Promise<void>;
+  renewLock(lockTokenOrMessage: string | ServiceBusMessage): Promise<Date>;
+  subscriptionName: string;
+  topicPath: string;
+}
+
+// @public
+interface SubscriptionClientOptions {
+  receiveMode?: ReceiveMode;
+}
+
+// @public
+class Timeout {
+  // (undocumented)
+  clear(): void;
+  // (undocumented)
+  set<T>(t: number, value?: T): Promise<T>;
+  // (undocumented)
+  wrap<T>(promise: Promise<T>, t: number, value?: T): Promise<T>;
+}
+
+// @public
+interface TokenInfo {
+  expiry: number;
+  token: string;
+  tokenType: TokenType;
+}
+
+// @public
+interface TokenProvider {
+  getToken(audience?: string): Promise<TokenInfo>;
+  tokenRenewalMarginInSeconds: number;
+  tokenValidTimeInSeconds: number;
+}
+
+// @public
+enum TokenType {
+  CbsTokenTypeJwt = "jwt",
+  CbsTokenTypeSas = "servicebus.windows.net:sastoken"
+}
+
+// @public
+class TopicClient extends Client {
+  // WARNING: The type "ConnectionContext" needs to be exported by the package (e.g. added to index.ts)
+  constructor(name: string, context: ConnectionContext);
+  cancelScheduledMessage(sequenceNumber: Long): Promise<void>;
+  cancelScheduledMessages(sequenceNumbers: Long[]): Promise<void>;
+  close(): Promise<any>;
+  scheduleMessage(message: SendableMessageInfo, scheduledEnqueueTimeUtc: Date): Promise<Long>;
+  scheduleMessages(messages: ScheduleMessage[]): Promise<Long[]>;
+  send(data: SendableMessageInfo): Promise<Delivery>;
+  sendBatch(datas: SendableMessageInfo[]): Promise<Delivery>;
+}
+
+// WARNING: Unsupported export: generateUuid
+// WARNING: Unsupported export: OnError
+// WARNING: Unsupported export: OnMessage
+// WARNING: Unsupported export: OnSessionMessage
+// (No @packagedocumentation comment for this package)

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,94 @@
         "tslib": "^1.9.3"
       }
     },
+    "@microsoft/api-extractor": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-6.3.0.tgz",
+      "integrity": "sha512-rhC3Wc/Zaj44W8hJYJlaf+gFGxVwLvSEOnPslYUi3anFbtXBNZpK3ocF10SgtSaca2QfKA8UNN1rCIwXUCdz7g==",
+      "dev": true,
+      "requires": {
+        "@microsoft/node-core-library": "3.7.0",
+        "@microsoft/ts-command-line": "4.2.2",
+        "@microsoft/tsdoc": "0.12.2",
+        "@types/node": "8.5.8",
+        "@types/z-schema": "3.16.31",
+        "colors": "~1.2.1",
+        "jju": "~1.3.0",
+        "lodash": "~4.17.5",
+        "resolve": "1.8.1",
+        "typescript": "~3.1.6",
+        "z-schema": "~3.18.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
+          "dev": true
+        },
+        "typescript": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+          "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+          "dev": true
+        }
+      }
+    },
+    "@microsoft/node-core-library": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-3.7.0.tgz",
+      "integrity": "sha512-Mae+MFnlcrcEmd6cmNzSv7xG74jWtQRlcOVjIwi10lECwm2LJIaiCol/PrsyARnjroDzf1eDH3quXSY7dTxLaA==",
+      "dev": true,
+      "requires": {
+        "@types/fs-extra": "5.0.4",
+        "@types/node": "8.5.8",
+        "@types/z-schema": "3.16.31",
+        "colors": "~1.2.1",
+        "fs-extra": "~7.0.1",
+        "jju": "~1.3.0",
+        "z-schema": "~3.18.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
+          "dev": true
+        }
+      }
+    },
+    "@microsoft/ts-command-line": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-4.2.2.tgz",
+      "integrity": "sha512-CLLVG+zWmUvD6jZD5oq7QCFYj3WOvrBSc3H6KejXCH6q2ntP5/ZHlmKVzQVvN1cEOSWP+jN9ml2AvUcDY/l6Tw==",
+      "dev": true,
+      "requires": {
+        "@types/argparse": "1.0.33",
+        "@types/node": "8.5.8",
+        "argparse": "~1.0.9",
+        "colors": "~1.2.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
+          "dev": true
+        }
+      }
+    },
+    "@microsoft/tsdoc": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.2.tgz",
+      "integrity": "sha512-L/srhENhBtbZLUD9FfJ2ZQdnYv3A3MT3UI2EMbC06fHUzIxLjjbkomD6o42UrbsRMwlS9p1BtxExeaCdX73q2Q==",
+      "dev": true
+    },
+    "@types/argparse": {
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.33.tgz",
+      "integrity": "sha512-VQgHxyPMTj3hIlq9SY1mctqx+Jj8kpQfoLvDlVSDNOyuYs8JYfkuY3OW/4+dO657yPmNhHpePRx0/Tje5ImNVQ==",
+      "dev": true
+    },
     "@types/async-lock": {
       "version": "1.1.0",
       "resolved": "http://registry.npmjs.org/@types/async-lock/-/async-lock-1.1.0.tgz",
@@ -53,6 +141,15 @@
         "@types/node": "*"
       }
     },
+    "@types/fs-extra": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
+      "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
@@ -69,6 +166,12 @@
       "version": "8.10.38",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.38.tgz",
       "integrity": "sha512-EibsnbJerd0hBFaDjJStFrVbVBAtOy4dgL8zZFw0uOvPqzBAX59Ci8cgjg3+RgJIWhsB5A4c+pi+D4P9tQQh/A=="
+    },
+    "@types/z-schema": {
+      "version": "3.16.31",
+      "resolved": "https://registry.npmjs.org/@types/z-schema/-/z-schema-3.16.31.tgz",
+      "integrity": "sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw=",
+      "dev": true
     },
     "adal-node": {
       "version": "0.1.28",
@@ -321,6 +424,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colors": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
@@ -468,6 +577,17 @@
         "mime-types": "^2.1.12"
       }
     },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -501,6 +621,12 @@
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -589,6 +715,12 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "jju": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
+      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
+      "dev": true
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -624,6 +756,15 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -664,6 +805,18 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
     },
     "long": {
       "version": "4.0.0",
@@ -3731,6 +3884,12 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
       "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -3743,6 +3902,12 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "validator": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-8.2.0.tgz",
+      "integrity": "sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA==",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",
@@ -3775,6 +3940,18 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
       "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
       "dev": true
+    },
+    "z-schema": {
+      "version": "3.18.4",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.18.4.tgz",
+      "integrity": "sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.7.1",
+        "lodash.get": "^4.0.0",
+        "lodash.isequal": "^4.0.0",
+        "validator": "^8.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
+    "@microsoft/api-extractor": "^6.3.0",
     "@types/async-lock": "^1.1.0",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
@@ -42,7 +43,8 @@
     "build": "npm run tslint && npm run tsc",
     "test": "npm run build",
     "unit": "nyc --reporter=lcov --reporter=text-lcov mocha -r ts-node/register -t 50000 test/**/*.spec.ts",
-    "prepack": "npm i && npm run build"
+    "prepack": "npm i && npm run build",
+    "extract-api": "api-extractor run --local"
   },
   "homepage": "http://github.com/azure/azure-servcie-bus-node",
   "repository": {


### PR DESCRIPTION
This commit adds API extractor and an npm task `extract-api`. It does
the following:

* Generates a dts rollup file of this library's entire surface area.
  This is presently being saved to /typings/index-rollup.d.ts, but
  should probably go into a different place eventually.
* Adds API baselines under ./etc. Every run of `extract-api` will check
  if the public surface area changed, and if so, say something on the
  console. A git diff of ./etc/service-bus.api.ts shows pretty clearly
  what APIs have changed.

A lot of warnings are generated here. Most seem to be due to different
doc tag conventions, but a few suggest maybe some pieces need to be
exported. Check the generated API file for more details (search for
"WARNING:").

Before accepting this PR, we should at least:

* [ ] Decide if we want to enable the API Review workflow or turn it off
* [ ] Confirm the rollup is accurate and if so replace the typings folder