### PR TITLE
Add Deferral sample

### DIFF
--- a/examples/samples/deferral.ts
+++ b/examples/samples/deferral.ts
@@ -35,7 +35,7 @@ async function sendMessage(): Promise<void> {
   var promises = new Array();
   for (let index = 0; index < data.length; index++) {
     const message: SendableMessageInfo = {
-      body: JSON.stringify(data[index]),
+      body: data[index],
       label: "RecipeStep",
       contentType: "application/json",
       timeToLive: 2 * 60 * 1000, // 2 minutes
@@ -69,7 +69,7 @@ async function receiveMessage(): Promise<void> {
         brokeredMessage.label === "RecipeStep" &&
         brokeredMessage.contentType === "application/json"
       ) {
-        const message = JSON.parse(brokeredMessage.body);
+        const message = brokeredMessage.body;
         // now let's check whether the step we received is the step we expect at this stage of the workflow
         if (message.step == lastProcessedRecipeStep + 1) {
           console.log("Message Received:", brokeredMessage.body ? message : null);
@@ -106,7 +106,7 @@ async function receiveMessage(): Promise<void> {
       const sequenceNumber = deferredSteps.get(curStep);
       const message = await receiveClient.receiveDeferredMessage(sequenceNumber);
       if (message) {
-        console.log("Received Deferral Message:", JSON.parse(message.body));
+        console.log("Received Deferral Message:", message.body);
         await message.complete();
       } else {
         console.log("No message found for step number ", curStep);

--- a/examples/samples/deferral.ts
+++ b/examples/samples/deferral.ts
@@ -1,0 +1,123 @@
+import {
+  OnMessage,
+  OnError,
+  MessagingError,
+  delay,
+  ServiceBusMessage,
+  ReceiveMode,
+  generateUuid,
+  Namespace,
+  SendableMessageInfo
+} from "../../lib";
+import * as dotenv from "dotenv";
+dotenv.config();
+
+const str = process.env.SERVICEBUS_CONNECTION_STRING || "";
+const path = process.env.QUEUE_NAME || "";
+console.log("str: ", str);
+console.log("path: ", path);
+
+async function main(): Promise<void> {
+  await sendMessage();
+  await receiveMessage();
+}
+
+async function sendMessage(): Promise<void> {
+  const nsSend = Namespace.createFromConnectionString(str);
+  const sendClient = nsSend.createQueueClient(path);
+  var data = [
+    { step: 1, title: "Shop" },
+    { step: 2, title: "Unpack" },
+    { step: 3, title: "Prepare" },
+    { step: 4, title: "Cook" },
+    { step: 5, title: "Eat" }
+  ];
+  try {
+    var promises = new Set<Promise<void>>();
+    for (let index = 0; index < data.length; index++) {
+      const message: SendableMessageInfo = {
+        body: JSON.stringify(data[index]),
+        label: "RecipeStep",
+        contentType: "application/json",
+        timeToLive: 2 * 60 * 1000, // 2 minutes
+        messageId: generateUuid()
+      };
+      // the way we shuffle the message order is to introduce a tiny random delay before each of the messages is sent
+      promises.add(
+        delay(Math.random() * 30).then(async () => {
+          await sendClient.send(message);
+          console.log("Sent message number:", index + 1);
+        })
+      );
+    }
+    // wait until all the send tasks are complete
+    for (let promise of promises) {
+      await promise;
+    }
+  } catch (err) {
+    console.log("Error while sending", err);
+  }
+  return nsSend.close();
+}
+
+async function receiveMessage(): Promise<void> {
+  const nsRcv = Namespace.createFromConnectionString(str);
+  const receiveClient = nsRcv.createQueueClient(path, { receiveMode: ReceiveMode.peekLock });
+  var deferredSteps = new Map();
+  var lastProcessedRecipeStep = 0;
+  try {
+    const onMessage: OnMessage = async (brokeredMessage: ServiceBusMessage) => {
+      if (
+        brokeredMessage.label === "RecipeStep" &&
+        brokeredMessage.contentType === "application/json"
+      ) {
+        // now let's check whether the step we received is the step we expect at this stage of the workflow
+        if (JSON.parse(brokeredMessage.body).step == lastProcessedRecipeStep + 1) {
+          console.log(
+            "Message Received:",
+            brokeredMessage.body ? JSON.parse(brokeredMessage.body) : null
+          );
+          lastProcessedRecipeStep = JSON.parse(brokeredMessage.body).step;
+          await brokeredMessage.complete();
+        } else {
+          // if this is not the step we expected, we defer the message, meaning that we leave it in the queue but take it out of
+          // the delivery order. We put it aside. To retrieve it later, we remeber its sequence number
+          const sequenceNumber = brokeredMessage.sequenceNumber!;
+          deferredSteps.set(JSON.parse(brokeredMessage.body).step, sequenceNumber);
+          await brokeredMessage.defer();
+        }
+      }
+    };
+    const onError: OnError = (err: MessagingError | Error) => {
+      console.log(">>>>> Error occurred: ", err);
+    };
+
+    const rcvHandler = receiveClient.receive(onMessage, onError, { autoComplete: false });
+    await delay(10000);
+    console.log("Deferred Messages size", deferredSteps.size);
+    // Now we process the deferrred steps
+    while (deferredSteps.size > 0) {
+      var step = lastProcessedRecipeStep + 1;
+      if (deferredSteps.has(step)) {
+        const sequenceNumber = deferredSteps.get(step);
+        const message = await receiveClient.receiveDeferredMessage(sequenceNumber);
+        console.log("Received Deferral Message:", message ? JSON.parse(message.body) : null);
+        await message!.complete();
+        lastProcessedRecipeStep = lastProcessedRecipeStep + 1;
+        deferredSteps.delete(lastProcessedRecipeStep);
+      }
+    }
+    await rcvHandler.stop();
+  } catch (err) {
+    console.log("Error while receiving: ", err);
+  }
+  return nsRcv.close();
+}
+
+main()
+  .then(() => {
+    console.log("\n>>>> sample Done!!!!");
+  })
+  .catch((err) => {
+    console.log("error: ", err);
+  });


### PR DESCRIPTION
The send-side of the sample takes an ordered list of workflow steps (Shop, Unpack, Prepare, Cook, Eat) and puts them into the queue. The way we're shuffling these into a random order is by adding a random delay of a few milliseconds (30 ms) before each send operation. Sending is done when all send tasks are done.

What we're expecting for processing our workflow are instructions for 5 steps (Shop, Unpack, Prepare, Cook, Eat) to arrive, and we can only process them in order. We could start preparing the meal before we have shopped for extra ingredients we're missing, but the outcome might be disappointing.

Once we received a recipe step, we check whether it's the step we're expecting to process next. If that is the case, we handle it and complete the message. If the message arrives out of the expected order, we defer the message for later processing.

This causes the message to be "put on the side" inside the queue. Once we're done with all the messages that were put into the queue, we then take care of the deferred messages and process the remaining steps in order. #45 