### PR TITLE
Use isItselfClosed() to determine if sdk initiatied close

### DIFF
--- a/lib/core/messageReceiver.ts
+++ b/lib/core/messageReceiver.ts
@@ -503,7 +503,7 @@ export class MessageReceiver extends LinkEntity {
           sbError
         );
         if (!sbError.retryable) {
-          if (receiver && !receiver.isClosed()) {
+          if (receiver && !receiver.isItselfClosed()) {
             log.error(
               "[%s] Since the user did not close the receiver and the error is not " +
                 "retryable, we let the user know about it by calling the user's error handler.",
@@ -539,7 +539,7 @@ export class MessageReceiver extends LinkEntity {
           this.name,
           sbError
         );
-        if (receiver && !receiver.isSessionClosed() && !sbError.retryable) {
+        if (receiver && !receiver.isSessionItselfClosed() && !sbError.retryable) {
           log.error(
             "[%s] Since the user did not close the receiver and the session error is not " +
               "retryable, we let the user know about it by calling the user's error handler.",
@@ -565,7 +565,7 @@ export class MessageReceiver extends LinkEntity {
         );
       }
       this._clearAllMessageLockRenewTimers();
-      if (receiver && !receiver.isClosed()) {
+      if (receiver && !receiver.isItselfClosed()) {
         if (!this.isConnecting) {
           log.error(
             "[%s] 'receiver_close' event occurred on the receiver '%s' with address '%s' " +
@@ -613,7 +613,7 @@ export class MessageReceiver extends LinkEntity {
         );
       }
       this._clearAllMessageLockRenewTimers();
-      if (receiver && !receiver.isSessionClosed()) {
+      if (receiver && !receiver.isSessionItselfClosed()) {
         if (!this.isConnecting) {
           log.error(
             "[%s] 'session_close' event occurred on the session of receiver '%s' with " +
@@ -656,13 +656,11 @@ export class MessageReceiver extends LinkEntity {
   async detached(receiverError?: AmqpError | Error): Promise<void> {
     const connectionId = this._context.namespace.connectionId;
     try {
-      const wasCloseInitiated = this._receiver && this._receiver.isClosed();
+      const wasCloseInitiated = this._receiver && this._receiver.isItselfClosed();
       // Clears the token renewal timer. Closes the link and its session if they are open.
       // Removes the link and its session if they are present in rhea's cache.
       await this._closeLink(this._receiver);
-      // For session_close and receiver_close this should attempt to reopen
-      // only when the receiver(sdk) did not initiate the close) OR
-      // if an error is present and the error is retryable.
+      // We should attempt to reopen only when the receiver(sdk) did not initiate the close
       let shouldReopen = false;
       if (receiverError && !wasCloseInitiated) {
         const translatedError = translate(receiverError);

--- a/lib/core/messageSender.ts
+++ b/lib/core/messageSender.ts
@@ -128,7 +128,7 @@ export class MessageSender extends LinkEntity {
           senderError
         );
       }
-      if (sender && !sender.isClosed()) {
+      if (sender && !sender.isItselfClosed()) {
         if (!this.isConnecting) {
           log.error(
             "[%s] 'sender_close' event occurred on the sender '%s' with address '%s' " +
@@ -174,7 +174,7 @@ export class MessageSender extends LinkEntity {
           sessionError
         );
       }
-      if (sender && !sender.isSessionClosed()) {
+      if (sender && !sender.isSessionItselfClosed()) {
         if (!this.isConnecting) {
           log.error(
             "[%s] 'session_close' event occurred on the session of sender '%s' with " +
@@ -216,13 +216,11 @@ export class MessageSender extends LinkEntity {
    */
   async detached(senderError?: AmqpError | Error): Promise<void> {
     try {
-      const wasCloseInitiated = this._sender && this._sender.isClosed();
+      const wasCloseInitiated = this._sender && this._sender.isItselfClosed();
       // Clears the token renewal timer. Closes the link and its session if they are open.
       // Removes the link and its session if they are present in rhea's cache.
       await this._closeLink(this._sender);
-      // For session_close and sender_close this should attempt to reopen
-      // only when the sender(sdk) did not initiate the close) OR
-      // if an error is present and the error is retryable.
+      // We should attempt to reopen only when the sender(sdk) did not initiate the close
       let shouldReopen = false;
       if (senderError && !wasCloseInitiated) {
         const translatedError = translate(senderError);

--- a/lib/session/messageSession.ts
+++ b/lib/session/messageSession.ts
@@ -356,7 +356,7 @@ export class MessageSession extends LinkEntity {
         // no need to notify the user's error handler since rhea guarantees that receiver_error
         // will always be emitted before receiver_close.
       }
-      if (receiver && !receiver.isClosed()) {
+      if (receiver && !receiver.isItselfClosed()) {
         log.error(
           "[%s] 'receiver_close' event occurred on the receiver '%s' for sessionId '%s' " +
             "and the sdk did not initiate this. Hence, let's gracefully close the receiver.",
@@ -404,7 +404,7 @@ export class MessageSession extends LinkEntity {
         // will always be emitted before session_close.
       }
 
-      if (receiver && !receiver.isSessionClosed()) {
+      if (receiver && !receiver.isSessionItselfClosed()) {
         log.error(
           "[%s] 'session_close' event occurred on the receiver '%s' for sessionId '%s' " +
             "and the sdk did not initiate this. Hence, let's gracefully close the receiver.",


### PR DESCRIPTION
## Description

Brief description of the changes made in the PR. This helps in making better changelog
- Use `isItselfClosed()` instead of `isClosed()` to determine if the sdk has initiated the close
- Remove comment that indicated that we should attempt to reopen sender/receivers for retryable errors even when sdk has intiated the close()

## Reference to any github issues
- https://github.com/amqp/rhea/issues/170

cc @amarzavery 
