### PR TITLE
Use descriptorCodes from amqp-common

### DIFF
--- a/lib/core/managementClient.ts
+++ b/lib/core/managementClient.ts
@@ -29,7 +29,7 @@ import * as log from "../log";
 import { ReceiveMode } from "./messageReceiver";
 import { reorderLockTokens, toBuffer } from "../util/utils";
 import { Typed } from "rhea/typings/types";
-import { max32BitNumber, descriptorCodes } from "../util/constants";
+import { max32BitNumber } from "../util/constants";
 
 /**
  * @ignore
@@ -1085,7 +1085,7 @@ export class ManagementClient extends LinkEntity {
         if (
           !ruleDescriptor ||
           !ruleDescriptor.descriptor ||
-          ruleDescriptor.descriptor.value !== descriptorCodes.ruleDescriptionList ||
+          ruleDescriptor.descriptor.value !== Constants.descriptorCodes.ruleDescriptionList ||
           !Array.isArray(ruleDescriptor.value) ||
           ruleDescriptor.value.length < 3
         ) {
@@ -1099,22 +1099,22 @@ export class ManagementClient extends LinkEntity {
         };
 
         switch (filtersRawData.descriptor.value) {
-          case descriptorCodes.trueFilterList:
+          case Constants.descriptorCodes.trueFilterList:
             rule.filter = {
               expression: "1=1"
             };
             break;
-          case descriptorCodes.falseFilterList:
+          case Constants.descriptorCodes.falseFilterList:
             rule.filter = {
               expression: "1=0"
             };
             break;
-          case descriptorCodes.sqlFilterList:
+          case Constants.descriptorCodes.sqlFilterList:
             rule.filter = {
               expression: this._safelyGetTypedValueFromArray(filtersRawData.value, 0)
             };
             break;
-          case descriptorCodes.correlationFilterList:
+          case Constants.descriptorCodes.correlationFilterList:
             rule.filter = {
               correlationId: this._safelyGetTypedValueFromArray(filtersRawData.value, 0),
               messageId: this._safelyGetTypedValueFromArray(filtersRawData.value, 1),
@@ -1135,7 +1135,7 @@ export class ManagementClient extends LinkEntity {
         }
 
         if (
-          actionsRawData.descriptor.value === descriptorCodes.sqlRuleActionList &&
+          actionsRawData.descriptor.value === Constants.descriptorCodes.sqlRuleActionList &&
           Array.isArray(actionsRawData.value) &&
           actionsRawData.value.length
         ) {

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -8,12 +8,3 @@ export const packageJsonInfo = {
 export const messageDispositionTimeout = 20000;
 
 export const max32BitNumber = Math.pow(2, 31) - 1;
-
-export const descriptorCodes = {
-  ruleDescriptionList: 1335734829060,
-  sqlFilterList: 83483426822,
-  correlationFilterList: 83483426825,
-  sqlRuleActionList: 1335734829062,
-  trueFilterList: 83483426823,
-  falseFilterList: 83483426824
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@azure/amqp-common": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@azure/amqp-common/-/amqp-common-0.1.8.tgz",
-      "integrity": "sha512-sXngWHZ9fJ6L2MFG+sFFBmtnQqoJwRZL68dPiAQVy0nTrxPfiMFjl2Us4Qj5oe2SP3x7X54xxP1mpuZQWNQ0nA==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@azure/amqp-common/-/amqp-common-0.1.9.tgz",
+      "integrity": "sha512-B/HFWNbqAjFjhj8x/zlHcpuYtsr92l3ZVArJdumi2kpN2Di/h4g6GIa2JeQEDD+rkLa3oAR6zHKfJbGnybOmvg==",
       "requires": {
         "async-lock": "^1.1.3",
         "debug": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/lib/index.js",
   "types": "./typings/lib/index.d.ts",
   "dependencies": {
-    "@azure/amqp-common": "^0.1.8",
+    "@azure/amqp-common": "^0.1.9",
     "debug": "^3.1.0",
     "is-buffer": "^2.0.3",
     "long": "^4.0.0",


### PR DESCRIPTION
## Description

[Previously](https://github.com/Azure/azure-service-bus-node/commit/1b8dea568c1771d40398b59736fcf180127eed48#diff-5dea45ff6af62c0805b1e43f12ae0c64), we had added descriptorCodes for working with Topic Filters in the constants file. A better home for these is the `amqp-common` library. This PR updates our code to use these codes from the `amqp-common` library

