### PR TITLE
Skip reconnecting batching receiver when connection fails

### DIFF
--- a/lib/core/messageReceiver.ts
+++ b/lib/core/messageReceiver.ts
@@ -662,6 +662,18 @@ export class MessageReceiver extends LinkEntity {
       // Clears the token renewal timer. Closes the link and its session if they are open.
       // Removes the link and its session if they are present in rhea's cache.
       await this._closeLink(this._receiver);
+
+      if (this.receiverType === ReceiverType.batching) {
+        log.error(
+          "[%s] Receiver '%s' with address '%s' is a Batching Receiver, so we will not be " +
+            "re-establishing the receiver link.",
+          connectionId,
+          this.name,
+          this.address
+        );
+        return;
+      }
+
       // For session_close and receiver_close this should attempt to reopen
       // only when the receiver(sdk) did not initiate the close) OR
       // if an error is present and the error is retryable.


### PR DESCRIPTION
## Description

As described in https://github.com/Azure/azure-service-bus-node/issues/33, reconnecting the batching receiver link when the connection fails is not something we want to do
