### PR TITLE
Updating batchingReceiver to use drain to empty out credits.

### DIFF
--- a/lib/core/batchingReceiver.ts
+++ b/lib/core/batchingReceiver.ts
@@ -101,8 +101,9 @@ export class BatchingReceiver extends MessageReceiver {
 
         if (this._receiver && this._receiver.credit > 0) {
           log.batching(
-            "[%s] Draining leftover credits (%s).",
+            "[%s] Receiver '%s': Draining leftover credits(%d).",
             this._context.namespace.connectionId,
+            this.name,
             this._receiver.credit
           );
 
@@ -116,9 +117,10 @@ export class BatchingReceiver extends MessageReceiver {
 
           this.isReceivingMessages = false;
           log.batching(
-            "[%s] Resolving the promise with received list of messages: %O.",
+            "[%s] Receiver '%s': Resolving receiveBatch() with %d messages.",
             this._context.namespace.connectionId,
-            brokeredMessages
+            this.name,
+            brokeredMessages.length
           );
           resolve(brokeredMessages);
         }
@@ -153,15 +155,11 @@ export class BatchingReceiver extends MessageReceiver {
 
         this.isReceivingMessages = false;
 
-        const returnMsg =
-          brokeredMessages.length > 0
-            ? "partial batch of " + brokeredMessages.length + " messages"
-            : "empty batch";
         log.batching(
-          "[%s] Receiver '%s' drained. Resolving promise with %s.",
+          "[%s] Receiver '%s' drained. Resolving receiveBatch() with %d messages.",
           this._context.namespace.connectionId,
           this.name,
-          returnMsg
+          brokeredMessages.length
         );
 
         resolve(brokeredMessages);

--- a/lib/core/batchingReceiver.ts
+++ b/lib/core/batchingReceiver.ts
@@ -112,6 +112,7 @@ export class BatchingReceiver extends MessageReceiver {
           }
         } else {
           this.isReceivingMessages = false;
+          resolve(brokeredMessages);
         }
       };
 

--- a/lib/session/messageSession.ts
+++ b/lib/session/messageSession.ts
@@ -479,7 +479,7 @@ export class MessageSession extends LinkEntity {
    */
   isOpen(): boolean {
     const result: boolean = this._receiver! && this._receiver!.isOpen();
-    log.error(
+    log.messageSession(
       "[%s] Receiver '%s' for sessionId '%s' is open? -> %s",
       this._context.namespace.connectionId,
       this.name,


### PR DESCRIPTION
## Description  
When calling receiveBatch sequentially on the same client instance, there is a credit leak if the previous batch received fewer than maxMessageCount. batchingReceiver should be be setting the drain flow control flag as described in http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-transport-v1.0-os.html#doc-flow-control in order to drain-off unused credits.

Brief description of the changes made in the PR:
- Added onReceiveDrain event handler. The handler unsubscribes the listener and resolves the promise with the received messages (if any).
- Changed finalAction to check remaining credits. If there any, it sets the drain flag on the link to cause the sender to drain the credits. At completion, the onReceiveDrain handler is called. If there are no remaning credits, finalAction directly resolves the promise with the received messages. 

# Reference to any github issues
- https://github.com/Azure/azure-service-bus-node/issues/90
