### PR TITLE
Set delivery settled status when using peekLock.

### DIFF
--- a/lib/core/batchingReceiver.ts
+++ b/lib/core/batchingReceiver.ts
@@ -8,6 +8,7 @@ import { ServiceBusMessage } from "../serviceBusMessage";
 import {
   MessageReceiver,
   ReceiveOptions,
+  ReceiveMode,
   ReceiverType,
   PromiseLike,
   OnAmqpEventAsPromise
@@ -270,6 +271,10 @@ export class BatchingReceiver extends MessageReceiver {
             state && state.error ? state.error : state
           );
           if (settled && this._deliveryDispositionMap.has(id)) {
+            if (this.receiveMode === ReceiveMode.peekLock) {
+              delivery.update(true);
+            }
+
             const promise = this._deliveryDispositionMap.get(id) as PromiseLike;
             clearTimeout(promise.timer);
             log.receiver(

--- a/lib/core/messageReceiver.ts
+++ b/lib/core/messageReceiver.ts
@@ -296,6 +296,10 @@ export class MessageReceiver extends LinkEntity {
           state && state.error ? state.error : state
         );
         if (settled && this._deliveryDispositionMap.has(id)) {
+          if (this.receiveMode === ReceiveMode.peekLock) {
+            delivery.update(true);
+          }
+
           const promise = this._deliveryDispositionMap.get(id) as PromiseLike;
           clearTimeout(promise.timer);
           log.receiver(

--- a/lib/session/messageSession.ts
+++ b/lib/session/messageSession.ts
@@ -284,6 +284,10 @@ export class MessageSession extends LinkEntity {
           state && state.error ? state.error : state
         );
         if (settled && this._deliveryDispositionMap.has(id)) {
+          if (this.receiveMode === ReceiveMode.peekLock) {
+            delivery.update(true);
+          }
+
           const promise = this._deliveryDispositionMap.get(id) as PromiseLike;
           clearTimeout(promise.timer);
           log.receiver(


### PR DESCRIPTION
Currently, in a single given instance of a receiver no more than 2047 messages can be received without closing and re-instantiating. This was because we were not settling the messages on complete/abandon/etc when using peekLock. This was causing deliveries to never be removed from Rhea's circular buffer.

Rhea settles messages for us on the accept/reject/etc calls when using receiveAndDelete mode, but when using peekLock we must update the delivery to be settled ourselves when we receive the onSettled event.

## Description

- Updating messageReceiver, batchingReceiver, and messageSession to update deliveries with settled=true when the onSettled event is received, and we are using peekLock.

# Reference to any github issues
- Issue #89 
