### PR TITLE
Make sure that we clear the map of deferred messages upon receiver closed

### DIFF
--- a/lib/queueClient.ts
+++ b/lib/queueClient.ts
@@ -84,9 +84,6 @@ export class QueueClient extends Client {
           await this._context.streamingReceiver.close();
         }
 
-        // Make sure that we clear the map of deferred messages
-        this._context.requestResponseLockedMessages.clear();
-
         // Close the batching receiver.
         if (this._context.batchingReceiver) {
           log.qClient("[%s] Closing the BatchingReceiver for queue '%s'.", connectionId, this.name);
@@ -103,6 +100,9 @@ export class QueueClient extends Client {
           );
           await this._context.messageSessions[messageSessionId].close();
         }
+
+        // Make sure that we clear the map of deferred messages
+        this._context.requestResponseLockedMessages.clear();
 
         log.qClient("Closed the Queue client '%s'.", this.id);
       }

--- a/lib/queueClient.ts
+++ b/lib/queueClient.ts
@@ -84,6 +84,9 @@ export class QueueClient extends Client {
           await this._context.streamingReceiver.close();
         }
 
+        // Make sure that we clear the map of deferred messages
+        this._context.requestResponseLockedMessages.clear();
+
         // Close the batching receiver.
         if (this._context.batchingReceiver) {
           log.qClient("[%s] Closing the BatchingReceiver for queue '%s'.", connectionId, this.name);

--- a/lib/util/concurrentExpiringMap.ts
+++ b/lib/util/concurrentExpiringMap.ts
@@ -50,8 +50,12 @@ export class ConcurrentExpiringMap<TKey> {
     return result;
   }
 
+  clear(): void {
+    this._map.clear();
+  }
+
   private async _scheduleCleanup(): Promise<void> {
-    if (this._cleanupScheduled || this._map.size < 0) {
+    if (this._cleanupScheduled || this._map.size <= 0) {
       return;
     }
 
@@ -64,6 +68,10 @@ export class ConcurrentExpiringMap<TKey> {
   }
 
   private async _collectExpiredEntries(): Promise<void> {
+    if (this._map.size === 0) {
+      return;
+    }
+
     await delay(this._delayBetweenCleanupInSeconds);
     this._cleanupScheduled = false;
     for (const key of this._map.keys()) {

--- a/lib/util/concurrentExpiringMap.ts
+++ b/lib/util/concurrentExpiringMap.ts
@@ -55,7 +55,7 @@ export class ConcurrentExpiringMap<TKey> {
   }
 
   private async _scheduleCleanup(): Promise<void> {
-    if (this._cleanupScheduled || this._map.size <= 0) {
+    if (this._cleanupScheduled || this._map.size === 0) {
       return;
     }
 


### PR DESCRIPTION
-	When a deferred message is received, it is added to the requestResponseLockedMessages concurrent queue.
-	That concurrent map has a policy that will try to clean-up expired messages from the map. It does that by calling itself in a recursive function every 30 miliseconds or so.
-	Because the code keeps running, the sample does not exit.

/cc @amarzavery @ramya-rao-a 