### PR TITLE
Remove messages from the deferral map once the messages are dispositioned

### DIFF
--- a/lib/serviceBusMessage.ts
+++ b/lib/serviceBusMessage.ts
@@ -855,10 +855,14 @@ export class ServiceBusMessage implements ReceivedMessage {
       this.messageId
     );
     if (this._context.requestResponseLockedMessages.has(this.lockToken!)) {
-      return this._context.managementClient!.updateDispositionStatus(
+      await this._context.managementClient!.updateDispositionStatus(
         [this.lockToken!],
         DispositionStatus.completed
       );
+
+      // Remove the message from the internal map of deferred messages
+      this._context.requestResponseLockedMessages.delete(this.lockToken!);
+      return;
     }
     const receiver = this._context.getReceiver(this.delivery.link.name, this.sessionId);
     if (receiver) {
@@ -882,11 +886,15 @@ export class ServiceBusMessage implements ReceivedMessage {
       this.messageId
     );
     if (this._context.requestResponseLockedMessages.has(this.lockToken!)) {
-      return this._context.managementClient!.updateDispositionStatus(
+      await this._context.managementClient!.updateDispositionStatus(
         [this.lockToken!],
         DispositionStatus.abandoned,
         { propertiesToModify: propertiesToModify }
       );
+
+      // Remove the message from the internal map of deferred messages
+      this._context.requestResponseLockedMessages.delete(this.lockToken!);
+      return;
     }
     const receiver = this._context.getReceiver(this.delivery.link.name, this.sessionId);
     if (receiver) {
@@ -914,11 +922,15 @@ export class ServiceBusMessage implements ReceivedMessage {
       this.messageId
     );
     if (this._context.requestResponseLockedMessages.has(this.lockToken!)) {
-      return this._context.managementClient!.updateDispositionStatus(
+      await this._context.managementClient!.updateDispositionStatus(
         [this.lockToken!],
         DispositionStatus.defered,
         { propertiesToModify: propertiesToModify }
       );
+
+      // Remove the message from the internal map of deferred messages
+      this._context.requestResponseLockedMessages.delete(this.lockToken!);
+      return;
     }
     const receiver = this._context.getReceiver(this.delivery.link.name, this.sessionId);
     if (receiver) {
@@ -953,7 +965,7 @@ export class ServiceBusMessage implements ReceivedMessage {
       this.messageId
     );
     if (this._context.requestResponseLockedMessages.has(this.lockToken!)) {
-      return this._context.managementClient!.updateDispositionStatus(
+      await this._context.managementClient!.updateDispositionStatus(
         [this.lockToken!],
         DispositionStatus.suspended,
         {
@@ -961,6 +973,10 @@ export class ServiceBusMessage implements ReceivedMessage {
           deadLetterDescription: error.description
         }
       );
+
+      // Remove the message from the internal map of deferred messages
+      this._context.requestResponseLockedMessages.delete(this.lockToken!);
+      return;
     }
     const receiver = this._context.getReceiver(this.delivery.link.name, this.sessionId);
     if (receiver) {

--- a/lib/util/concurrentExpiringMap.ts
+++ b/lib/util/concurrentExpiringMap.ts
@@ -50,7 +50,21 @@ export class ConcurrentExpiringMap<TKey> {
     return result;
   }
 
+  /**
+   * Removes an entry from the the map if present
+   * @param key The key which needs to be removed from the map.
+   * @returns True if the key was found and removed from the map, False otherwise
+   */
+  delete(key: TKey): boolean {
+    log.map("Deleting key '%s' from the map", key);
+    return this._map.delete(key);
+  }
+
+  /**
+   * Clears all the entries from the underlying map.
+   */
   clear(): void {
+    log.map("Clearing the map of all the entries");
     this._map.clear();
   }
 


### PR DESCRIPTION
This will remove the deferred messages from the map once they are dispositioned successfully.

Fixes #121 