### PR TITLE
Fixing the bug - Completing an already completed message

### DIFF
--- a/lib/core/messageReceiver.ts
+++ b/lib/core/messageReceiver.ts
@@ -468,7 +468,11 @@ export class MessageReceiver extends LinkEntity {
 
       // If we've made it this far, then user's message handler completed fine. Let us try
       // completing the message.
-      if (this.autoComplete && this.receiveMode === ReceiveMode.peekLock) {
+      if (
+        this.autoComplete &&
+        this.receiveMode === ReceiveMode.peekLock &&
+        !bMessage.delivery.remote_settled
+      ) {
         try {
           log[this.receiverType](
             "[%s] Auto completing the message with id '%s' on " + "the receiver '%s'.",
@@ -476,9 +480,7 @@ export class MessageReceiver extends LinkEntity {
             bMessage.messageId,
             this.name
           );
-          if (!bMessage.delivery.remote_settled) {
-            await bMessage.complete();
-          }
+          await bMessage.complete();
         } catch (completeError) {
           const translatedError = translate(completeError);
           log.error(

--- a/lib/core/messageReceiver.ts
+++ b/lib/core/messageReceiver.ts
@@ -476,7 +476,9 @@ export class MessageReceiver extends LinkEntity {
             bMessage.messageId,
             this.name
           );
-          await bMessage.complete();
+          if (!bMessage.delivery.remote_settled) {
+            await bMessage.complete();
+          }
         } catch (completeError) {
           const translatedError = translate(completeError);
           log.error(


### PR DESCRIPTION
## Description
**Issue** - https://github.com/Azure/azure-service-bus-node/issues/145

**Steps to reproduce the behavior**
- Use a streaming receiver (by default autoComplete will be enabled)
- Complete the message in the onMessage callback (`await message.complete()`)
- The program takes more time to exit(about 20 seconds more) when added `await message.complete()` call in the onMessage callback.

**Observations**
- The actual workflow with `await message.complete()` call in the onMessage callback is 
    - `complete() -> _onSettled() -> second complete()`.
- The reason for taking more time is [timer attribute of _deliveryDispositionMap(settimeout())]( https://github.com/Azure/azure-service-bus-node/blob/18f114dbfa0395b94de7380d8af9ceac26e8b560/lib/core/messageReceiver.ts#L781) is not getting cleared [Which actually happens in the ` _onSettled() ` event handler] 
   -  `_onSettled()` is not executed after the second `complete()` call[that came from the autoComplete being true by default].
- We don't have to call complete() method for the second time if the message gets settled by the first call.
- `delivery.remote_settled` gets updated to true when the message is settled.
-  So, we can check the property(`delivery.remote_settled`) just before making the second complete() call and make the call if that property is not true.
-------------------------------

**Changes in the PR**
- If `autoComplete` is `true`, `await bMessage.complete()` gets executed all the time without checking the  `delivery.remote_settled`. 
- We'd have to check the `delivery.remote_settled` and if it is false, then execute `await bMessage.complete()` 


The second `complete()` call.
https://github.com/Azure/azure-service-bus-node/blob/18f114dbfa0395b94de7380d8af9ceac26e8b560/lib/core/messageReceiver.ts#L479 
So, the above line of code changes to
```typescript 
if (!bMessage.delivery.remote_settled) {
       await bMessage.complete();
}
```
This would prevent calling `complete()` on a settled message.
# Reference to any github issues
- https://github.com/Azure/azure-service-bus-node/issues/145



@AlexGhiondea @ramya-rao-a @ShivangiReja @ramya0820 