### PR TITLE
Fix AutoComplete Bug in messageSession.ts

### DIFF
--- a/lib/session/messageSession.ts
+++ b/lib/session/messageSession.ts
@@ -567,7 +567,11 @@ export class MessageSession extends LinkEntity {
 
         // If we've made it this far, then user's message handler completed fine. Let us try
         // completing the message.
-        if (this.autoComplete && this.receiveMode === ReceiveMode.peekLock) {
+        if (
+          this.autoComplete &&
+          this.receiveMode === ReceiveMode.peekLock &&
+          !bMessage.delivery.remote_settled
+        ) {
           try {
             log.messageSession(
               "[%s] Auto completing the message with id '%s' on " + "the receiver '%s'.",


### PR DESCRIPTION
## Description
messageSession.ts 
- Added check to know if the message is settled before calling the `complete()` method(coming from the `autoComplete` being true)
https://github.com/Azure/azure-service-bus-node/blob/fb7b77b5b9c6c67612ab69300d55c9dfc77abdb1/lib/session/messageSession.ts#L582
# Reference to any github issues
- https://github.com/Azure/azure-service-bus-node/issues/145
- https://github.com/Azure/azure-service-bus-node/pull/154
