### PR TITLE
Streaming Receiver Tests - Part 3

### DIFF
--- a/test/streamingReceiver.spec.ts
+++ b/test/streamingReceiver.spec.ts
@@ -16,7 +16,8 @@ import {
   ServiceBusMessage,
   TopicClient,
   SubscriptionClient,
-  delay
+  delay,
+  ReceiveHandler
 } from "../lib";
 
 const testMessages: SendableMessageInfo[] = [
@@ -402,6 +403,55 @@ describe("Streaming Receiver from Queue/Subscription", function(): void {
     await testPeekMsgsLength(subscriptionClient, 0);
   });
 
+  it("With auto-complete enabled, manual abandon in the Queue by the user should not result in errors", async function(): Promise<
+    void
+  > {
+    await queueClient.send(testMessages[0]);
+    const receiveListener: ReceiveHandler = await queueClient.receive(
+      (msg: ServiceBusMessage) => {
+        return msg.abandon().then(() => {
+          return receiveListener.stop();
+        });
+      },
+      (err: Error) => {
+        should.not.exist(err);
+      },
+      { maxAutoRenewDurationInSeconds: 0 }
+    );
+    await delay(4000);
+
+    const receivedMsgs = await queueClient.receiveBatch(1);
+    should.equal(receivedMsgs.length, 1);
+    should.equal(receivedMsgs[0].messageId, testMessages[0].messageId);
+    await receivedMsgs[0].complete();
+    await testPeekMsgsLength(queueClient, 0);
+  });
+
+  it("With auto-complete enabled, manual abandon in the Subscription by the user should not result in errors", async function(): Promise<
+    void
+  > {
+    await topicClient.send(testMessages[0]);
+    const receiveListener: ReceiveHandler = await subscriptionClient.receive(
+      (msg: ServiceBusMessage) => {
+        return msg.abandon().then(() => {
+          return receiveListener.stop();
+        });
+      },
+      (err: Error) => {
+        should.not.exist(err);
+      },
+      { maxAutoRenewDurationInSeconds: 0 }
+    );
+
+    await delay(4000);
+
+    const receivedMsgs = await subscriptionClient.receiveBatch(1);
+    should.equal(receivedMsgs.length, 1);
+    should.equal(receivedMsgs[0].messageId, testMessages[0].messageId);
+    await receivedMsgs[0].complete();
+    await testPeekMsgsLength(subscriptionClient, 0);
+  });
+
   it("With auto-complete enabled, manual deadletter in the Queue by the user should not result in errors", async function(): Promise<
     void
   > {
@@ -477,6 +527,93 @@ describe("Streaming Receiver from Queue/Subscription", function(): void {
     await deadLetterMsgs[1].complete();
 
     await testPeekMsgsLength(deadletterSubscriptionClient, 0);
+  });
+
+  it("With auto-complete enabled, manual defer in the Queue by the user should not result in errors", async function(): Promise<
+    void
+  > {
+    await queueClient.sendBatch(testMessages);
+
+    let seq0: any = 0;
+    let seq1: any = 0;
+    const receiveListener = await queueClient.receive(
+      (msg: ServiceBusMessage) => {
+        if (msg.messageId === testMessages[0].messageId) {
+          seq0 = msg.sequenceNumber;
+        } else if (msg.messageId === testMessages[1].messageId) {
+          seq1 = msg.sequenceNumber;
+        }
+        return msg.defer();
+      },
+      (err: Error) => {
+        should.not.exist(err);
+      }
+    );
+
+    await delay(4000);
+
+    await receiveListener.stop();
+    const deferredMsg0 = await queueClient.receiveDeferredMessage(seq0);
+    const deferredMsg1 = await queueClient.receiveDeferredMessage(seq1);
+    if (!deferredMsg0) {
+      throw "No message received for sequence number";
+    }
+    if (!deferredMsg1) {
+      throw "No message received for sequence number";
+    }
+    should.equal(deferredMsg0.body, testMessages[0].body);
+    should.equal(deferredMsg0.messageId, testMessages[0].messageId);
+
+    should.equal(deferredMsg1.body, testMessages[1].body);
+    should.equal(deferredMsg1.messageId, testMessages[1].messageId);
+    await deferredMsg0.complete();
+    await deferredMsg1.complete();
+
+    await testPeekMsgsLength(queueClient, 0);
+  });
+
+  it("With auto-complete enabled, manual defer in the Subscription by the user should not result in errors", async function(): Promise<
+    void
+  > {
+    await topicClient.sendBatch(testMessages);
+
+    let seq0: any = 0;
+    let seq1: any = 0;
+    const receiveListener = await subscriptionClient.receive(
+      (msg: ServiceBusMessage) => {
+        if (msg.messageId === testMessages[0].messageId) {
+          seq0 = msg.sequenceNumber;
+        } else if (msg.messageId === testMessages[1].messageId) {
+          seq1 = msg.sequenceNumber;
+        }
+        return msg.defer();
+      },
+      (err: Error) => {
+        should.not.exist(err);
+      }
+    );
+
+    await delay(4000);
+
+    await receiveListener.stop();
+
+    const deferredMsg0 = await subscriptionClient.receiveDeferredMessage(seq0);
+    const deferredMsg1 = await subscriptionClient.receiveDeferredMessage(seq1);
+    if (!deferredMsg0) {
+      throw "No message received for sequence number";
+    }
+    if (!deferredMsg1) {
+      throw "No message received for sequence number";
+    }
+    should.equal(deferredMsg0.body, testMessages[0].body);
+    should.equal(deferredMsg0.messageId, testMessages[0].messageId);
+
+    should.equal(deferredMsg1.body, testMessages[1].body);
+    should.equal(deferredMsg1.messageId, testMessages[1].messageId);
+    await deferredMsg0.complete();
+    await deferredMsg1.complete();
+
+    await testPeekMsgsLength(subscriptionClient, 0);
   });
 
   it("With auto-complete disabled, deferring a message results in not getting the same message again from queue. The message is then gotten using receiveDefferedMessages", async function(): Promise<


### PR DESCRIPTION
**With auto-complete enabled, manual abandon/defer in the Queue/Subscription by the user should not result in errors.** (Using Partitioned Queues and Subscriptions)
- abandon(Queue)
- abandon(Subscription)
- defer(Queue)
- defer(Subscription)


**Note :**  Clearing the messages using `receive()` did not work(second receive() didn't get invoked). So, cleared the messages using `receiveBatch()` instead.


# Reference to any github issues
- #101 
