### PR TITLE
Refactoring StreamingReceiver Tests to re-use code across test cases

### DIFF
--- a/test/batchReceiver.spec.ts
+++ b/test/batchReceiver.spec.ts
@@ -35,7 +35,11 @@ async function testPeekMsgsLength(
   expectedPeekLength: number
 ): Promise<void> {
   const peekedMsgs = await client.peek(expectedPeekLength + 1);
-  should.equal(peekedMsgs.length, expectedPeekLength);
+  should.equal(
+    peekedMsgs.length,
+    expectedPeekLength,
+    "Unexpected number of msgs found when peeking"
+  );
 }
 
 const maxDeliveryCount = 10;
@@ -156,7 +160,7 @@ describe("Complete/Abandon/Defer/Deadletter normal message", () => {
     await testComplete(queueClient, queueClient);
   });
 
-  it("Queue: complete() removes message", async function(): Promise<void> {
+  it("Subscription: complete() removes message", async function(): Promise<void> {
     await testComplete(topicClient, subscriptionClient);
   });
 
@@ -172,13 +176,13 @@ describe("Complete/Abandon/Defer/Deadletter normal message", () => {
     await completeMessages(receiverClient, 1);
   }
 
-  it("Queue: Abandoned message is retained with incremented deliveryCount", async function(): Promise<
+  it("Queue: abandon() retains message with incremented deliveryCount", async function(): Promise<
     void
   > {
     await testAbandon(queueClient, queueClient);
   });
 
-  it("Subscription: Abandoned message is retained with incremented deliveryCount", async function(): Promise<
+  it("Subscription: abandon() retains message with incremented deliveryCount", async function(): Promise<
     void
   > {
     await testAbandon(topicClient, subscriptionClient);
@@ -209,13 +213,11 @@ describe("Complete/Abandon/Defer/Deadletter normal message", () => {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Queue: Receive deferred message from queue/subscription", async function(): Promise<void> {
+  it("Queue: defer() moves message to deferred queue", async function(): Promise<void> {
     await testDefer(queueClient, queueClient);
   });
 
-  it("Subscription: Receive deferred message from queue/subscription", async function(): Promise<
-    void
-  > {
+  it("Subscription: defer() moves message to deferred queue", async function(): Promise<void> {
     await testDefer(topicClient, subscriptionClient);
   });
 
@@ -232,11 +234,11 @@ describe("Complete/Abandon/Defer/Deadletter normal message", () => {
     await completeMessages(deadLetterClient, 0);
   }
 
-  it("Queue: Receive dead letter message from queue/subscription", async function(): Promise<void> {
+  it("Queue: deadLetter() moves message to deadletter queue", async function(): Promise<void> {
     await testDeadletter(queueClient, queueClient, deadletterQueueClient);
   });
 
-  it("Subscription: Receive dead letter message from queue/subscription", async function(): Promise<
+  it("Subscription: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await testDeadletter(topicClient, subscriptionClient, deadletterSubscriptionClient);
@@ -601,7 +603,7 @@ describe("Multiple ReceiveBatch calls", () => {
   });
 });
 
-describe("Other ReceiveBatch Tests", function(): void {
+describe("Batching Receiver Misc Tests", function(): void {
   beforeEach(async () => {
     await beforeEachTest();
   });

--- a/test/streamingReceiver.spec.ts
+++ b/test/streamingReceiver.spec.ts
@@ -587,7 +587,7 @@ describe("With autocomplete enabled, test Complete/Abandon/Defer/Deadletter norm
   });
 });
 
-describe.only("With autocomplete disabled, test Complete/Abandon/Defer/Deadletter normal message", function(): void {
+describe("With autocomplete disabled, test Complete/Abandon/Defer/Deadletter normal message", function(): void {
   beforeEach(async () => {
     await beforeEachTest();
   });

--- a/test/streamingReceiver.spec.ts
+++ b/test/streamingReceiver.spec.ts
@@ -105,7 +105,7 @@ async function afterEachTest(): Promise<void> {
   await namespace.close();
 }
 
-describe.only("Streaming Receiver Misc Tests", function(): void {
+describe("Streaming Receiver Misc Tests", function(): void {
   beforeEach(async () => {
     await beforeEachTest();
   });

--- a/test/streamingReceiver.spec.ts
+++ b/test/streamingReceiver.spec.ts
@@ -114,12 +114,15 @@ describe("Streaming Receiver Misc Tests", function(): void {
     await afterEachTest();
   });
 
-  it("AutoComplete removes the message from Queue", async function(): Promise<void> {
-    await queueClient.sendBatch(testMessages);
-    await testPeekMsgsLength(queueClient, testMessages.length);
+  async function testAutoComplete(
+    senderClient: QueueClient | TopicClient,
+    receiverClient: QueueClient | SubscriptionClient
+  ): Promise<void> {
+    await senderClient.sendBatch(testMessages);
+    await testPeekMsgsLength(receiverClient, testMessages.length);
 
     const receivedMsgs: ServiceBusMessage[] = [];
-    const receiveListener = queueClient.receive(
+    const receiveListener = receiverClient.receive(
       (msg: ServiceBusMessage) => {
         receivedMsgs.push(msg);
         should.equal(
@@ -141,37 +144,15 @@ describe("Streaming Receiver Misc Tests", function(): void {
     }
 
     await receiveListener.stop();
-    await testPeekMsgsLength(queueClient, 0);
+    await testPeekMsgsLength(receiverClient, 0);
+  }
+
+  it("AutoComplete removes the message from Queue", async function(): Promise<void> {
+    await testAutoComplete(queueClient, queueClient);
   });
 
   it("AutoComplete removes the message from Subscription", async function(): Promise<void> {
-    await topicClient.sendBatch(testMessages);
-    await testPeekMsgsLength(subscriptionClient, testMessages.length);
-
-    const receivedMsgs: ServiceBusMessage[] = [];
-    const receiveListener = subscriptionClient.receive(
-      (msg: ServiceBusMessage) => {
-        receivedMsgs.push(msg);
-        should.equal(
-          testMessages.some((x) => msg.body === x.body && msg.messageId === x.messageId),
-          true
-        );
-        return Promise.resolve();
-      },
-      (err: Error) => {
-        should.not.exist(err);
-      }
-    );
-
-    for (let i = 0; i < 5; i++) {
-      await delay(1000);
-      if (receivedMsgs.length === testMessages.length) {
-        break;
-      }
-    }
-
-    await receiveListener.stop();
-    await testPeekMsgsLength(subscriptionClient, 0);
+    await testAutoComplete(topicClient, subscriptionClient);
   });
 
   it("Disabled autoComplete, no manual complete retains the message in Queue", async function(): Promise<
@@ -596,11 +577,14 @@ describe("With autocomplete disabled, test Complete/Abandon/Defer/Deadletter nor
     await afterEachTest();
   });
 
-  it("Queue: complete() removes message", async function(): Promise<void> {
-    await queueClient.sendBatch(testMessages);
+  async function testComplete(
+    senderClient: QueueClient | TopicClient,
+    receiverClient: QueueClient | SubscriptionClient
+  ): Promise<void> {
+    await senderClient.sendBatch(testMessages);
 
     const receivedMsgs: ServiceBusMessage[] = [];
-    const receiveListener = queueClient.receive(
+    const receiveListener = receiverClient.receive(
       (msg: ServiceBusMessage) => {
         receivedMsgs.push(msg);
         should.equal(
@@ -622,47 +606,24 @@ describe("With autocomplete disabled, test Complete/Abandon/Defer/Deadletter nor
       }
     }
 
-    await testPeekMsgsLength(queueClient, 0);
+    await testPeekMsgsLength(receiverClient, 0);
 
     await receiveListener.stop();
+  }
+  it("Queue: complete() removes message", async function(): Promise<void> {
+    await testComplete(queueClient, queueClient);
   });
 
   it("Subscription: complete() removes message", async function(): Promise<void> {
-    await topicClient.sendBatch(testMessages);
-
-    const receivedMsgs: ServiceBusMessage[] = [];
-    const receiveListener = subscriptionClient.receive(
-      (msg: ServiceBusMessage) => {
-        receivedMsgs.push(msg);
-        should.equal(
-          testMessages.some((x) => msg.body === x.body && msg.messageId === x.messageId),
-          true
-        );
-        return msg.complete();
-      },
-      (err: Error) => {
-        should.not.exist(err);
-      },
-      { autoComplete: false }
-    );
-
-    for (let i = 0; i < 5; i++) {
-      await delay(1000);
-      if (receivedMsgs.length === testMessages.length) {
-        break;
-      }
-    }
-
-    await testPeekMsgsLength(subscriptionClient, 0);
-
-    await receiveListener.stop();
+    await testComplete(topicClient, subscriptionClient);
   });
 
-  it("Queue: abandon() retains message with incremented deliveryCount", async function(): Promise<
-    void
-  > {
-    await queueClient.send(testMessages[0]);
-    const receiveListener: ReceiveHandler = await queueClient.receive(
+  async function testAbandon(
+    senderClient: QueueClient | TopicClient,
+    receiverClient: QueueClient | SubscriptionClient
+  ): Promise<void> {
+    await senderClient.send(testMessages[0]);
+    const receiveListener: ReceiveHandler = await receiverClient.receive(
       (msg: ServiceBusMessage) => {
         return msg.abandon().then(() => {
           return receiveListener.stop();
@@ -675,46 +636,34 @@ describe("With autocomplete disabled, test Complete/Abandon/Defer/Deadletter nor
     );
     await delay(4000);
 
-    const receivedMsgs = await queueClient.receiveBatch(1);
+    const receivedMsgs = await receiverClient.receiveBatch(1);
     should.equal(receivedMsgs.length, 1);
     should.equal(receivedMsgs[0].messageId, testMessages[0].messageId);
     // should.equal(receivedMsgs[0].deliveryCount, 1);
     await receivedMsgs[0].complete();
-    await testPeekMsgsLength(queueClient, 0);
+    await testPeekMsgsLength(receiverClient, 0);
+  }
+  it("Queue: abandon() retains message with incremented deliveryCount", async function(): Promise<
+    void
+  > {
+    await testAbandon(queueClient, queueClient);
   });
 
   it("Subscription: abandon() retains message with incremented deliveryCount", async function(): Promise<
     void
   > {
-    await topicClient.send(testMessages[0]);
-    const receiveListener: ReceiveHandler = await subscriptionClient.receive(
-      (msg: ServiceBusMessage) => {
-        return msg.abandon().then(() => {
-          return receiveListener.stop();
-        });
-      },
-      (err: Error) => {
-        should.not.exist(err);
-      },
-      { maxAutoRenewDurationInSeconds: 0, autoComplete: false }
-    );
-
-    await delay(4000);
-
-    const receivedMsgs = await subscriptionClient.receiveBatch(1);
-    should.equal(receivedMsgs.length, 1);
-    should.equal(receivedMsgs[0].messageId, testMessages[0].messageId);
-    // should.equal(receivedMsgs[0].deliveryCount, 1);
-    await receivedMsgs[0].complete();
-    await testPeekMsgsLength(subscriptionClient, 0);
+    await testAbandon(topicClient, subscriptionClient);
   });
 
-  it("Queue: defer() moves message to deferred queue", async function(): Promise<void> {
-    await queueClient.sendBatch(testMessages);
+  async function testDefer(
+    senderClient: QueueClient | TopicClient,
+    receiverClient: QueueClient | SubscriptionClient
+  ): Promise<void> {
+    await senderClient.sendBatch(testMessages);
 
     let seq0: any = 0;
     let seq1: any = 0;
-    const receiveListener = await queueClient.receive(
+    const receiveListener = await receiverClient.receive(
       (msg: ServiceBusMessage) => {
         if (msg.messageId === testMessages[0].messageId) {
           seq0 = msg.sequenceNumber;
@@ -732,8 +681,8 @@ describe("With autocomplete disabled, test Complete/Abandon/Defer/Deadletter nor
     await delay(4000);
 
     await receiveListener.stop();
-    const deferredMsg0 = await queueClient.receiveDeferredMessage(seq0);
-    const deferredMsg1 = await queueClient.receiveDeferredMessage(seq1);
+    const deferredMsg0 = await receiverClient.receiveDeferredMessage(seq0);
+    const deferredMsg1 = await receiverClient.receiveDeferredMessage(seq1);
     if (!deferredMsg0) {
       throw "No message received for sequence number";
     }
@@ -748,56 +697,24 @@ describe("With autocomplete disabled, test Complete/Abandon/Defer/Deadletter nor
     await deferredMsg0.complete();
     await deferredMsg1.complete();
 
-    await testPeekMsgsLength(queueClient, 0);
+    await testPeekMsgsLength(receiverClient, 0);
+  }
+  it("Queue: defer() moves message to deferred queue", async function(): Promise<void> {
+    await testDefer(queueClient, queueClient);
   });
 
   it("Subscription: defer() moves message to deferred queue", async function(): Promise<void> {
-    await topicClient.sendBatch(testMessages);
-
-    let seq0: any = 0;
-    let seq1: any = 0;
-    const receiveListener = await subscriptionClient.receive(
-      (msg: ServiceBusMessage) => {
-        if (msg.messageId === testMessages[0].messageId) {
-          seq0 = msg.sequenceNumber;
-        } else if (msg.messageId === testMessages[1].messageId) {
-          seq1 = msg.sequenceNumber;
-        }
-        return msg.defer();
-      },
-      (err: Error) => {
-        should.not.exist(err);
-      },
-      { autoComplete: false }
-    );
-
-    await delay(4000);
-
-    await receiveListener.stop();
-
-    const deferredMsg0 = await subscriptionClient.receiveDeferredMessage(seq0);
-    const deferredMsg1 = await subscriptionClient.receiveDeferredMessage(seq1);
-    if (!deferredMsg0) {
-      throw "No message received for sequence number";
-    }
-    if (!deferredMsg1) {
-      throw "No message received for sequence number";
-    }
-    should.equal(deferredMsg0.body, testMessages[0].body);
-    should.equal(deferredMsg0.messageId, testMessages[0].messageId);
-
-    should.equal(deferredMsg1.body, testMessages[1].body);
-    should.equal(deferredMsg1.messageId, testMessages[1].messageId);
-    await deferredMsg0.complete();
-    await deferredMsg1.complete();
-
-    await testPeekMsgsLength(subscriptionClient, 0);
+    await testDefer(topicClient, subscriptionClient);
   });
 
-  it("Queue: deadLetter() moves message to deadletter queue", async function(): Promise<void> {
-    await queueClient.sendBatch(testMessages);
-    await testPeekMsgsLength(queueClient, 2);
-    const receiveListener = await queueClient.receive(
+  async function testDeadletter(
+    senderClient: QueueClient | TopicClient,
+    receiverClient: QueueClient | SubscriptionClient,
+    deadletterClient: QueueClient | SubscriptionClient
+  ): Promise<void> {
+    await senderClient.sendBatch(testMessages);
+    await testPeekMsgsLength(receiverClient, 2);
+    const receiveListener = await receiverClient.receive(
       (msg: ServiceBusMessage) => {
         return msg.deadLetter();
       },
@@ -810,9 +727,9 @@ describe("With autocomplete disabled, test Complete/Abandon/Defer/Deadletter nor
     await delay(4000);
     await receiveListener.stop();
 
-    await testPeekMsgsLength(queueClient, 0);
+    await testPeekMsgsLength(receiverClient, 0);
 
-    const deadLetterMsgs = await deadletterQueueClient.receiveBatch(2);
+    const deadLetterMsgs = await deadletterClient.receiveBatch(2);
     should.equal(Array.isArray(deadLetterMsgs), true);
     should.equal(deadLetterMsgs.length, testMessages.length);
     should.equal(testMessages.some((x) => deadLetterMsgs[0].messageId === x.messageId), true);
@@ -821,42 +738,17 @@ describe("With autocomplete disabled, test Complete/Abandon/Defer/Deadletter nor
     await deadLetterMsgs[0].complete();
     await deadLetterMsgs[1].complete();
 
-    await testPeekMsgsLength(deadletterQueueClient, 0);
+    await testPeekMsgsLength(deadletterClient, 0);
+  }
+
+  it("Queue: deadLetter() moves message to deadletter queue", async function(): Promise<void> {
+    await testDeadletter(queueClient, queueClient, deadletterQueueClient);
   });
 
   it("Subscription: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
-    await topicClient.sendBatch(testMessages);
-
-    const receiveListener = await subscriptionClient.receive(
-      (msg: ServiceBusMessage) => {
-        return msg.deadLetter();
-      },
-      (err: Error) => {
-        should.not.exist(err);
-      },
-      { autoComplete: false }
-    );
-
-    await delay(4000);
-
-    await receiveListener.stop();
-
-    await testPeekMsgsLength(subscriptionClient, 0);
-
-    await testPeekMsgsLength(deadletterSubscriptionClient, 2); // Two messages in the DL
-
-    const deadLetterMsgs = await deadletterSubscriptionClient.receiveBatch(2);
-    should.equal(Array.isArray(deadLetterMsgs), true);
-    should.equal(deadLetterMsgs.length, testMessages.length);
-    should.equal(testMessages.some((x) => deadLetterMsgs[0].messageId === x.messageId), true);
-    should.equal(testMessages.some((x) => deadLetterMsgs[1].messageId === x.messageId), true);
-
-    await deadLetterMsgs[0].complete();
-    await deadLetterMsgs[1].complete();
-
-    await testPeekMsgsLength(deadletterSubscriptionClient, 0);
+    await testDeadletter(topicClient, subscriptionClient, deadletterSubscriptionClient);
   });
 });
 
@@ -869,10 +761,10 @@ describe("Multiple Streaming Receivers", function(): void {
     await afterEachTest();
   });
 
-  it("Second Streaming Receiver call should fail if the first one is not stopped for Queues", async function(): Promise<
-    void
-  > {
-    const receiveListener: ReceiveHandler = await queueClient.receive(
+  async function testMultipleReceiveBatchCalls(
+    receiverClient: QueueClient | SubscriptionClient
+  ): Promise<void> {
+    const receiveListener: ReceiveHandler = await receiverClient.receive(
       (msg: ServiceBusMessage) => {
         return msg.complete();
       },
@@ -882,7 +774,7 @@ describe("Multiple Streaming Receivers", function(): void {
     );
     await delay(5000);
     try {
-      const receiveListener2 = await queueClient.receive(
+      const receiveListener2 = await receiverClient.receive(
         (msg: ServiceBusMessage) => {
           return Promise.resolve();
         },
@@ -896,35 +788,17 @@ describe("Multiple Streaming Receivers", function(): void {
     }
 
     await receiveListener.stop();
+  }
+
+  it("Second Streaming Receiver call should fail if the first one is not stopped for Queues", async function(): Promise<
+    void
+  > {
+    await testMultipleReceiveBatchCalls(queueClient);
   });
 
   it("Second Streaming Receiver call should fail if the first one is not stopped for Subscriptions", async function(): Promise<
     void
   > {
-    const receiveListener: ReceiveHandler = await subscriptionClient.receive(
-      (msg: ServiceBusMessage) => {
-        return msg.complete();
-      },
-      (err: Error) => {
-        should.not.exist(err);
-      }
-    );
-    await delay(5000);
-
-    try {
-      const receiveListener2 = await subscriptionClient.receive(
-        (msg: ServiceBusMessage) => {
-          return Promise.resolve();
-        },
-        (err: Error) => {
-          should.exist(err);
-        }
-      );
-      await receiveListener2.stop();
-    } catch (err) {
-      should.equal(!err.message.search("has already been created for the Subscription"), false);
-    }
-
-    await receiveListener.stop();
+    await testMultipleReceiveBatchCalls(subscriptionClient);
   });
 });


### PR DESCRIPTION
### Description


Net changes in this PR:
- FIFO is not guaranteed unless we use sessions. Tests that expect `receivedMsgs` and `testMessages` to have contents in the same order are updated accordingly
- Tests are broken into separate logical chunks. This will help future maintaince
- Re-use test code between Queues and Subscriptions, autocomplete enable/disable
- Repeated code is moved to a common place
- Test descriptions updated to match the ones in the tests for the batching receiver
- Increased the time that we wait before stopping the receiveListener as it kept getting stopped before the messages were received.
- Add tests for abandon() when autoComplete is disabled
