### PR TITLE
Second Streaming Receiver call should fail if the first one is not stopped

### DIFF
--- a/test/streamingReceiver.spec.ts
+++ b/test/streamingReceiver.spec.ts
@@ -549,6 +549,7 @@ describe("Multiple Streaming Receivers", function(): void {
       }
     );
     await delay(5000);
+    let ERROR_FLAG = 0;
     try {
       const receiveListener2 = await receiverClient.receive(
         (msg: ServiceBusMessage) => {
@@ -560,8 +561,10 @@ describe("Multiple Streaming Receivers", function(): void {
       );
       await receiveListener2.stop();
     } catch (err) {
+      ERROR_FLAG = 1;
       should.equal(!err.message.search("has already been created for the Subscription"), false);
     }
+    should.equal(ERROR_FLAG, 1);
 
     await receiveListener.stop();
   }

--- a/test/streamingReceiver.spec.ts
+++ b/test/streamingReceiver.spec.ts
@@ -549,7 +549,7 @@ describe("Multiple Streaming Receivers", function(): void {
       }
     );
     await delay(5000);
-    let ERROR_FLAG = 0;
+    let errorWasThrown = false;
     try {
       const receiveListener2 = await receiverClient.receive(
         (msg: ServiceBusMessage) => {
@@ -561,10 +561,10 @@ describe("Multiple Streaming Receivers", function(): void {
       );
       await receiveListener2.stop();
     } catch (err) {
-      ERROR_FLAG = 1;
+      errorWasThrown = true;
       should.equal(!err.message.search("has already been created for the Subscription"), false);
     }
-    should.equal(ERROR_FLAG, 1);
+    should.equal(errorWasThrown, true);
 
     await receiveListener.stop();
   }


### PR DESCRIPTION
Second Streaming Receiver call - added a flag to check that it throws an error

## Description
Second Streaming Receiver call should fail if the first one is not stopped
> The test does check the error message in the catch() block. But this only guarantees that the error message is the expected one assuming that the error was indeed thrown. But there is nothing in the test that tests that the error indeed was thrown.
https://github.com/Azure/azure-service-bus-node/issues/101#issuecomment-454153613

# Reference to any github issues
- #101 
