### PR TITLE
Use same code when sending sequencenumbers to rhea

### DIFF
--- a/lib/core/managementClient.ts
+++ b/lib/core/managementClient.ts
@@ -677,11 +677,30 @@ export class ManagementClient extends LinkEntity {
     }
 
     const messageList: ServiceBusMessage[] = [];
+    const messageBody: any = {};
+    messageBody[Constants.sequenceNumbers] = [];
+    for (let i = 0; i < sequenceNumbers.length; i++) {
+      const sequenceNumber = sequenceNumbers[i];
+      if (!Long.isLong(sequenceNumber)) {
+        throw new Error("An item in the 'sequenceNumbers' Array must be an instance of 'Long'.");
+      }
+      try {
+        messageBody[Constants.sequenceNumbers].push(Buffer.from(sequenceNumber.toBytesBE()));
+      } catch (err) {
+        const error = translate(err);
+        log.error(
+          "An error occurred while encoding the item at position %d in the " +
+            "sequenceNumbers array: %O",
+          i,
+          error
+        );
+        throw error;
+      }
+    }
 
     try {
-      const messageBody: any = {};
-      messageBody["sequence-numbers"] = types.wrap_array(
-        sequenceNumbers.map((i) => Buffer.from(i.toBytesBE())),
+      messageBody[Constants.sequenceNumbers] = types.wrap_array(
+        messageBody[Constants.sequenceNumbers],
         0x81,
         undefined
       );


### PR DESCRIPTION
Both the [receiveDeferredMessages](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-amqp-request-response#deferred-message-operations) and [cancelScheduledMessages](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-amqp-request-response#cancel-scheduled-message) requests pass in the the array of sequence numbers in the request body.

This PR updates the `receiveDeferredMessages` call in this SDK to use the same code as `cancelScheduledMessages` for setting the sequence numbers in the message body.

This is part of the work to fix the issue described in #146

