### PR TITLE
Settle an already settled message test case.

### DIFF
--- a/lib/serviceBusMessage.ts
+++ b/lib/serviceBusMessage.ts
@@ -870,6 +870,9 @@ export class ServiceBusMessage implements ReceivedMessage {
       if (receiver.receiveMode !== ReceiveMode.peekLock) {
         throw new Error("The operation is only supported in 'PeekLock' receive mode.");
       }
+      if (this.delivery.remote_settled) {
+        throw new Error("This Message has been already settled.");
+      }
       return receiver.settleMessage(this, DispositionType.complete);
     } else {
       throw new Error(`Cannot find the receiver with name '${this.delivery.link.name}'.`);
@@ -904,6 +907,9 @@ export class ServiceBusMessage implements ReceivedMessage {
     if (receiver) {
       if (receiver.receiveMode !== ReceiveMode.peekLock) {
         throw new Error("The operation is only supported in 'PeekLock' receive mode.");
+      }
+      if (this.delivery.remote_settled) {
+        throw new Error("This Message has been already settled.");
       }
       return receiver.settleMessage(this, DispositionType.abandon, {
         propertiesToModify: propertiesToModify
@@ -943,6 +949,9 @@ export class ServiceBusMessage implements ReceivedMessage {
     if (receiver) {
       if (receiver.receiveMode !== ReceiveMode.peekLock) {
         throw new Error("The operation is only supported in 'PeekLock' receive mode.");
+      }
+      if (this.delivery.remote_settled) {
+        throw new Error("This Message has been already settled.");
       }
       return receiver.settleMessage(this, DispositionType.defer, {
         propertiesToModify: propertiesToModify
@@ -991,6 +1000,9 @@ export class ServiceBusMessage implements ReceivedMessage {
     if (receiver) {
       if (receiver.receiveMode !== ReceiveMode.peekLock) {
         throw new Error("The operation is only supported in 'PeekLock' receive mode.");
+      }
+      if (this.delivery.remote_settled) {
+        throw new Error("This Message has been already settled.");
       }
       return receiver.settleMessage(this, DispositionType.deadletter, {
         error: error

--- a/lib/serviceBusMessage.ts
+++ b/lib/serviceBusMessage.ts
@@ -871,7 +871,7 @@ export class ServiceBusMessage implements ReceivedMessage {
         throw new Error("The operation is only supported in 'PeekLock' receive mode.");
       }
       if (this.delivery.remote_settled) {
-        throw new Error("This Message has been already settled.");
+        throw new Error("This message has been already settled.");
       }
       return receiver.settleMessage(this, DispositionType.complete);
     } else {
@@ -909,7 +909,7 @@ export class ServiceBusMessage implements ReceivedMessage {
         throw new Error("The operation is only supported in 'PeekLock' receive mode.");
       }
       if (this.delivery.remote_settled) {
-        throw new Error("This Message has been already settled.");
+        throw new Error("This message has been already settled.");
       }
       return receiver.settleMessage(this, DispositionType.abandon, {
         propertiesToModify: propertiesToModify
@@ -951,7 +951,7 @@ export class ServiceBusMessage implements ReceivedMessage {
         throw new Error("The operation is only supported in 'PeekLock' receive mode.");
       }
       if (this.delivery.remote_settled) {
-        throw new Error("This Message has been already settled.");
+        throw new Error("This message has been already settled.");
       }
       return receiver.settleMessage(this, DispositionType.defer, {
         propertiesToModify: propertiesToModify
@@ -1002,7 +1002,7 @@ export class ServiceBusMessage implements ReceivedMessage {
         throw new Error("The operation is only supported in 'PeekLock' receive mode.");
       }
       if (this.delivery.remote_settled) {
-        throw new Error("This Message has been already settled.");
+        throw new Error("This message has been already settled.");
       }
       return receiver.settleMessage(this, DispositionType.deadletter, {
         error: error

--- a/test/streamingReceiver.spec.ts
+++ b/test/streamingReceiver.spec.ts
@@ -20,6 +20,8 @@ import {
   ReceiveHandler
 } from "../lib";
 
+import { DispositionType } from "../lib/core/messageReceiver";
+
 const testMessages: SendableMessageInfo[] = [
   {
     body: "hello1",
@@ -50,6 +52,7 @@ let topicClient: TopicClient;
 let subscriptionClient: SubscriptionClient;
 let deadletterQueueClient: QueueClient;
 let deadletterSubscriptionClient: SubscriptionClient;
+let errorWasThrown: boolean;
 
 async function beforeEachTest(): Promise<void> {
   // The tests in this file expect the env variables to contain the connection string and
@@ -99,6 +102,7 @@ async function beforeEachTest(): Promise<void> {
   if (peekedSubscriptionMsg.length) {
     throw new Error("Please use an empty Subscription for integration testing");
   }
+  errorWasThrown = false;
 }
 
 async function afterEachTest(): Promise<void> {
@@ -579,5 +583,94 @@ describe("Multiple Streaming Receivers", function(): void {
     void
   > {
     await testMultipleReceiveCalls(subscriptionClient);
+  });
+
+  describe("Settle an already Settled message throws error", () => {
+    beforeEach(async () => {
+      await beforeEachTest();
+    });
+
+    afterEach(async () => {
+      await afterEachTest();
+    });
+
+    const testError = (err: Error) => {
+      should.equal(err.message, "This Message has been already settled.");
+      errorWasThrown = true;
+    };
+
+    async function testSettlement(
+      senderClient: QueueClient | TopicClient,
+      receiverClient: QueueClient | SubscriptionClient,
+      operation: DispositionType
+    ): Promise<void> {
+      await senderClient.send(testMessages[0]);
+      const receivedMsgs: ServiceBusMessage[] = [];
+      const receiveListener = receiverClient.receive(
+        (msg: ServiceBusMessage) => {
+          receivedMsgs.push(msg);
+          return Promise.resolve();
+        },
+        (err: Error) => {
+          should.not.exist(err);
+        }
+      );
+
+      await delay(2000);
+
+      should.equal(receivedMsgs.length, 1);
+      should.equal(receivedMsgs[0].body, testMessages[0].body);
+      should.equal(receivedMsgs[0].messageId, testMessages[0].messageId);
+      should.equal(receivedMsgs[0].body, testMessages[0].body);
+      should.equal(receivedMsgs[0].messageId, testMessages[0].messageId);
+
+      await testPeekMsgsLength(receiverClient, 0);
+
+      if (operation === DispositionType.complete) {
+        await receivedMsgs[0].complete().catch((err) => testError(err));
+      } else if (operation === DispositionType.abandon) {
+        await receivedMsgs[0].abandon().catch((err) => testError(err));
+      } else if (operation === DispositionType.deadletter) {
+        await receivedMsgs[0].deadLetter().catch((err) => testError(err));
+      } else if (operation === DispositionType.defer) {
+        await receivedMsgs[0].defer().catch((err) => testError(err));
+      }
+
+      should.equal(errorWasThrown, true);
+
+      await receiveListener.stop();
+    }
+
+    it("Queue: complete() throws error", async function(): Promise<void> {
+      await testSettlement(queueClient, queueClient, DispositionType.complete);
+    });
+
+    it("Subscription: complete() throws error", async function(): Promise<void> {
+      await testSettlement(topicClient, subscriptionClient, DispositionType.complete);
+    });
+
+    it("Queue: abandon() throws error", async function(): Promise<void> {
+      await testSettlement(queueClient, queueClient, DispositionType.abandon);
+    });
+
+    it("Subscription: abandon() throws error", async function(): Promise<void> {
+      await testSettlement(topicClient, subscriptionClient, DispositionType.abandon);
+    });
+
+    it("Queue: defer() throws error", async function(): Promise<void> {
+      await testSettlement(queueClient, queueClient, DispositionType.defer);
+    });
+
+    it("Subscription: defer() throws error", async function(): Promise<void> {
+      await testSettlement(topicClient, subscriptionClient, DispositionType.defer);
+    });
+
+    it("Queue: deadLetter() throws error", async function(): Promise<void> {
+      await testSettlement(queueClient, queueClient, DispositionType.deadletter);
+    });
+
+    it("Subscription: deadLetter()", async function(): Promise<void> {
+      await testSettlement(topicClient, subscriptionClient, DispositionType.deadletter);
+    });
   });
 });

--- a/test/streamingReceiver.spec.ts
+++ b/test/streamingReceiver.spec.ts
@@ -553,7 +553,6 @@ describe("Multiple Streaming Receivers", function(): void {
       }
     );
     await delay(5000);
-    let errorWasThrown = false;
     try {
       const receiveListener2 = await receiverClient.receive(
         (msg: ServiceBusMessage) => {
@@ -595,7 +594,7 @@ describe("Multiple Streaming Receivers", function(): void {
     });
 
     const testError = (err: Error) => {
-      should.equal(err.message, "This Message has been already settled.");
+      should.equal(err.message, "This message has been already settled.");
       errorWasThrown = true;
     };
 
@@ -619,8 +618,6 @@ describe("Multiple Streaming Receivers", function(): void {
       await delay(2000);
 
       should.equal(receivedMsgs.length, 1);
-      should.equal(receivedMsgs[0].body, testMessages[0].body);
-      should.equal(receivedMsgs[0].messageId, testMessages[0].messageId);
       should.equal(receivedMsgs[0].body, testMessages[0].body);
       should.equal(receivedMsgs[0].messageId, testMessages[0].messageId);
 


### PR DESCRIPTION
Implemented following test cases

1. Throws error when  complete/defer/abandon/deadletter already settled message.
2. User tries to settle messages received when in ReceiveAndDelete mode. In this case, the message is settled way before it even reaches the user.(Already covered this case in this issue #174)
