### PR TITLE
Simplify func signature for scheduling messages

### DIFF
--- a/examples/samples/scheduledMessages.ts
+++ b/examples/samples/scheduledMessages.ts
@@ -22,7 +22,7 @@ async function sendMessages(queueClient: QueueClient, data: any[]): Promise<void
     console.log(
       `>>>> Sending message:\t ${message.body}, scheduled for UTC: ${scheduledEnqueueTimeUtc}`
     );
-    await queueClient.scheduleMessage(message, scheduledEnqueueTimeUtc);
+    await queueClient.scheduleMessage(scheduledEnqueueTimeUtc, message);
   }
 }
 

--- a/examples/schedule.ts
+++ b/examples/schedule.ts
@@ -12,10 +12,9 @@ async function main(): Promise<void> {
   ns = Namespace.createFromConnectionString(str);
   const client = ns.createQueueClient(path);
   const scheduleTime = new Date(Date.now() + 30000); // 30 seconds from now
-  const sequenceNumber = await client.scheduleMessage(
-    { body: "Hello sb world!!" + scheduleTime.toString() },
-    scheduleTime
-  );
+  const sequenceNumber = await client.scheduleMessage(scheduleTime, {
+    body: "Hello sb world!!" + scheduleTime.toString()
+  });
   console.log("***********Created sender and sent the message... %d", sequenceNumber);
   await delay(3000);
   console.log(">>>> Cancelling the scheduled message");

--- a/examples/scheduleMultiple.ts
+++ b/examples/scheduleMultiple.ts
@@ -1,4 +1,4 @@
-import { Namespace, delay, ScheduleMessage } from "../lib";
+import { Namespace, delay, SendableMessageInfo } from "../lib";
 import * as dotenv from "dotenv";
 dotenv.config();
 
@@ -11,19 +11,12 @@ let ns: Namespace;
 async function main(): Promise<void> {
   ns = Namespace.createFromConnectionString(str);
   const client = ns.createQueueClient(path);
-  const scheduleTime1 = new Date(Date.now() + 30000); // 30 seconds from now
-  const scheduleTime2 = new Date(Date.now() + 32000); // 32 seconds from now
-  const messages: ScheduleMessage[] = [
-    {
-      message: { body: "Hello sb world!!" + scheduleTime1.toString() },
-      scheduledEnqueueTimeUtc: scheduleTime1
-    },
-    {
-      message: { body: "Hello sb world!!" + scheduleTime2.toString() },
-      scheduledEnqueueTimeUtc: scheduleTime2
-    }
+  const scheduleTime = new Date(Date.now() + 30000); // 30 seconds from now
+  const messages: SendableMessageInfo[] = [
+    { body: "Hello sb world!! 1" + scheduleTime.toString() },
+    { body: "Hello sb world!! 2" + scheduleTime.toString() }
   ];
-  const sequenceNumbers = await client.scheduleMessages(messages);
+  const sequenceNumbers = await client.scheduleMessages(scheduleTime, messages);
   console.log("***********Created sender and sent the message... %o", sequenceNumbers);
   await delay(3000);
   console.log(">>>> Cancelling scheduled messages");

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -42,9 +42,4 @@ export { QueueClientOptions, QueueClient } from "./queueClient";
 export { Namespace, NamespaceOptions } from "./namespace";
 export { TopicClient } from "./topicClient";
 export { SubscriptionClient, SubscriptionClientOptions } from "./subscriptionClient";
-export {
-  ScheduleMessage,
-  SQLExpression,
-  CorrelationFilter,
-  RuleDescription
-} from "./core/managementClient";
+export { SQLExpression, CorrelationFilter, RuleDescription } from "./core/managementClient";

--- a/lib/queueClient.ts
+++ b/lib/queueClient.ts
@@ -334,9 +334,8 @@ export class QueueClient extends Client {
   /**
    * Schedules a message to appear on Service Bus Queue at a later time.
    *
+   * @param scheduledEnqueueTimeUtc - The UTC time at which the message should be enqueued.
    * @param message - The message that needs to be scheduled.
-   * @param scheduledEnqueueTimeUtc - The UTC time at which the message should be available
-   * for processing.
    * @returns Promise<Long> - The sequence number of the message that was
    * scheduled. Please save the `Long` type as-is in your application. Do not convert it to a
    * number as that may cause loss of precision, since JS only supports 53 bit numbers.
@@ -346,8 +345,8 @@ export class QueueClient extends Client {
    * `Long.fromString("result");`. This will ensure that precision is preserved.
    */
   async scheduleMessage(
-    message: SendableMessageInfo,
-    scheduledEnqueueTimeUtc: Date
+    scheduledEnqueueTimeUtc: Date,
+    message: SendableMessageInfo
   ): Promise<Long> {
     const scheduleMessages: ScheduleMessage[] = [
       { message: message, scheduledEnqueueTimeUtc: scheduledEnqueueTimeUtc }
@@ -359,9 +358,8 @@ export class QueueClient extends Client {
   /**
    * Schedules a message to appear on Service Bus Queue at a later time.
    *
-   * @param message - Message that needs to be scheduled.
-   * @param scheduledEnqueueTimeUtc - The UTC time at which the message should be available
-   * for processing.
+   * @param scheduledEnqueueTimeUtc - The UTC time at which the message should be enqueued.
+   * @param messages - Array of Messages that need to be scheduled.
    * @returns Promise<Long[]> - The sequence numbers of messages that were scheduled. Please
    * save the `Long` type as-is in your application. Do not convert it to a number as that may
    * cause loss of precision, since JS only supports 53 bit numbers. `Long` type provides methods
@@ -369,8 +367,17 @@ export class QueueClient extends Client {
    * form `const result = Long.toString();`. When deserializing it, please use
    * `Long.fromString("result");`. This will ensure that precision is preserved.
    */
-  async scheduleMessages(messages: ScheduleMessage[]): Promise<Long[]> {
-    return this._context.managementClient!.scheduleMessages(messages);
+  async scheduleMessages(
+    scheduledEnqueueTimeUtc: Date,
+    messages: SendableMessageInfo[]
+  ): Promise<Long[]> {
+    const scheduleMessages: ScheduleMessage[] = messages.map((message) => {
+      return {
+        message,
+        scheduledEnqueueTimeUtc
+      };
+    });
+    return this._context.managementClient!.scheduleMessages(scheduleMessages);
   }
 
   /**

--- a/lib/topicClient.ts
+++ b/lib/topicClient.ts
@@ -88,9 +88,8 @@ export class TopicClient extends Client {
   /**
    * Schedules a message to appear on Service Bus at a later time.
    *
+   * @param scheduledEnqueueTimeUtc - The UTC time at which the message should be enqueued.
    * @param message - The message that needs to be scheduled.
-   * @param scheduledEnqueueTimeUtc - The UTC time at which the message should be available
-   * for processing.
    * @returns Promise<Long> - The sequence number of the message that was
    * scheduled. Please save the `Long` type as-is in your application. Do not convert it to a
    * number as that may cause loss of precision, since JS only supports 53 bit numbers.
@@ -100,8 +99,8 @@ export class TopicClient extends Client {
    * `Long.fromString("result");`. This will ensure that precision is preserved.
    */
   async scheduleMessage(
-    message: SendableMessageInfo,
-    scheduledEnqueueTimeUtc: Date
+    scheduledEnqueueTimeUtc: Date,
+    message: SendableMessageInfo
   ): Promise<Long> {
     const scheduleMessages: ScheduleMessage[] = [
       { message: message, scheduledEnqueueTimeUtc: scheduledEnqueueTimeUtc }
@@ -113,9 +112,8 @@ export class TopicClient extends Client {
   /**
    * Schedules a message to appear on a servicebus topic at a later time.
    *
-   * @param message - Message that needs to be scheduled.
-   * @param scheduledEnqueueTimeUtc - The UTC time at which the message should be available
-   * for processing.
+   * @param scheduledEnqueueTimeUtc - The UTC time at which the message should be enqueued.
+   * @param messages - Array of Messages that need to be scheduled.
    * @returns Promise<Long[]> - The sequence numbers of messages that were scheduled. Please
    * save the `Long` type as-is in your application. Do not convert it to a number as that may
    * cause loss of precision, since JS only supports 53 bit numbers. `Long` type provides methods
@@ -123,8 +121,17 @@ export class TopicClient extends Client {
    * form `const result = Long.toString();`. When deserializing it, please use
    * `Long.fromString("result");`. This will ensure that precision is preserved.
    */
-  async scheduleMessages(messages: ScheduleMessage[]): Promise<Long[]> {
-    return this._context.managementClient!.scheduleMessages(messages);
+  async scheduleMessages(
+    scheduledEnqueueTimeUtc: Date,
+    messages: SendableMessageInfo[]
+  ): Promise<Long[]> {
+    const scheduleMessages: ScheduleMessage[] = messages.map((message) => {
+      return {
+        message,
+        scheduledEnqueueTimeUtc
+      };
+    });
+    return this._context.managementClient!.scheduleMessages(scheduleMessages);
   }
 
   /**

--- a/test/send.spec.ts
+++ b/test/send.spec.ts
@@ -127,7 +127,7 @@ async function afterEachTest(): Promise<void> {
   await namespace.close();
 }
 
-describe.only("Send to Queue/Subscription", function(): void {
+describe("Send to Queue/Subscription", function(): void {
   beforeEach(async () => {
     await beforeEachTest();
   });
@@ -216,7 +216,7 @@ describe.only("Send to Queue/Subscription", function(): void {
     const scheduleTime = new Date(Date.now() + 10000); // 10 seconds from now
     await senderClient.scheduleMessages(scheduleTime, testMessages);
 
-    const msgs = await receiverClient.receiveBatch(1);
+    const msgs = await receiverClient.receiveBatch(2);
     should.equal(Array.isArray(msgs), true);
     should.equal(msgs.length, 2);
 
@@ -230,6 +230,7 @@ describe.only("Send to Queue/Subscription", function(): void {
     should.equal(msgs[1].messageId, testMessages[1].messageId);
 
     await msgs[0].complete();
+    await msgs[1].complete();
 
     await testPeekMsgsLength(receiverClient, 0);
   }

--- a/test/send.spec.ts
+++ b/test/send.spec.ts
@@ -127,7 +127,7 @@ async function afterEachTest(): Promise<void> {
   await namespace.close();
 }
 
-describe("Send to Queue/Subscription", function(): void {
+describe.only("Send to Queue/Subscription", function(): void {
   beforeEach(async () => {
     await beforeEachTest();
   });
@@ -175,7 +175,7 @@ describe("Send to Queue/Subscription", function(): void {
     receiverClient: QueueClient | SubscriptionClient
   ): Promise<void> {
     const scheduleTime = new Date(Date.now() + 10000); // 10 seconds from now
-    await senderClient.scheduleMessage(testMessages[0], scheduleTime);
+    await senderClient.scheduleMessage(scheduleTime, testMessages[0]);
 
     const msgs = await receiverClient.receiveBatch(1);
     const msgEnqueueTime = msgs[0].enqueuedTimeUtc ? msgs[0].enqueuedTimeUtc.valueOf() : 0;
@@ -208,6 +208,49 @@ describe("Send to Queue/Subscription", function(): void {
   > {
     await testScheduleMessage(unpartitionedTopicClient, unpartitionedSubscriptionClient);
   });
+
+  async function testScheduleMessages(
+    senderClient: QueueClient | TopicClient,
+    receiverClient: QueueClient | SubscriptionClient
+  ): Promise<void> {
+    const scheduleTime = new Date(Date.now() + 10000); // 10 seconds from now
+    await senderClient.scheduleMessages(scheduleTime, testMessages);
+
+    const msgs = await receiverClient.receiveBatch(1);
+    should.equal(Array.isArray(msgs), true);
+    should.equal(msgs.length, 2);
+
+    const msgEnqueueTime1 = msgs[0].enqueuedTimeUtc ? msgs[0].enqueuedTimeUtc.valueOf() : 0;
+    const msgEnqueueTime2 = msgs[1].enqueuedTimeUtc ? msgs[1].enqueuedTimeUtc.valueOf() : 0;
+
+    // checking received message enqueue time is greater or equal to the scheduled time.
+    should.equal(msgEnqueueTime1 - scheduleTime.valueOf() >= 0, true);
+    should.equal(msgEnqueueTime2 - scheduleTime.valueOf() >= 0, true);
+    should.equal(msgs[0].messageId, testMessages[0].messageId);
+    should.equal(msgs[1].messageId, testMessages[1].messageId);
+
+    await msgs[0].complete();
+
+    await testPeekMsgsLength(receiverClient, 0);
+  }
+
+  it("Schedule messages using Queues", async function(): Promise<void> {
+    await testScheduleMessages(partitionedQueueClient, partitionedQueueClient);
+  });
+
+  it("Schedule messages using Topics and Subscriptions", async function(): Promise<void> {
+    await testScheduleMessages(partitionedTopicClient, partitionedSubscriptionClient);
+  });
+
+  it("Schedule messages using UnPartitioned Queues", async function(): Promise<void> {
+    await testScheduleMessages(unpartitionedQueueClient, unpartitionedQueueClient);
+  });
+
+  it("Schedule messages using UnPartitioned Topics and Subscriptions", async function(): Promise<
+    void
+  > {
+    await testScheduleMessages(unpartitionedTopicClient, unpartitionedSubscriptionClient);
+  });
 });
 
 describe("Cancel Scheduled messages for sending to Queue/Subscription", function(): void {
@@ -224,7 +267,7 @@ describe("Cancel Scheduled messages for sending to Queue/Subscription", function
     receiverClient: QueueClient | SubscriptionClient
   ): Promise<void> {
     const scheduleTime = new Date(Date.now() + 30000); // 30 seconds from now as anything less gives inconsistent results for cancelling
-    const sequenceNumber = await senderClient.scheduleMessage(testMessages[0], scheduleTime);
+    const sequenceNumber = await senderClient.scheduleMessage(scheduleTime, testMessages[0]);
 
     await delay(2000);
 
@@ -261,8 +304,8 @@ describe("Cancel Scheduled messages for sending to Queue/Subscription", function
     msgs: SendableMessageInfo[]
   ): Promise<void> {
     const scheduleTime = new Date(Date.now() + 30000); // 30 seconds from now as anything less gives inconsistent results for cancelling
-    const sequenceNumber1 = await senderClient.scheduleMessage(msgs[0], scheduleTime);
-    const sequenceNumber2 = await senderClient.scheduleMessage(msgs[1], scheduleTime);
+    const sequenceNumber1 = await senderClient.scheduleMessage(scheduleTime, msgs[0]);
+    const sequenceNumber2 = await senderClient.scheduleMessage(scheduleTime, msgs[1]);
 
     await delay(2000);
 


### PR DESCRIPTION
Related to #173 

This PR updates the function signature for `scheduleMessage` and `scheduleMessages` to

- Use scheduleTime before the messages to be consistent with Go & Python SDK. This will also help in the future if we decide to use [rest parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters)
- Update `scheduleMessages` to only support a single schedule time instead of separate ones for each message. 
   - This makes the signature similar to that of `scheduleMessage`
   - Avoids the user having to create a new object "ScheduleMessage"
   - Makes feature consistent with Go & Python SDK
- Removes `ScheduleMessage` from index.ts as it is need not be exported and made visible to the user anymore

