### PR TITLE
Fix failing tests

### DIFF
--- a/lib/session/messageSession.ts
+++ b/lib/session/messageSession.ts
@@ -625,7 +625,7 @@ export class MessageSession extends LinkEntity {
    * 10% of the lockDuration value.
    * - **Default**: `2` seconds.
    */
-  receiveBatch(
+  async receiveBatch(
     maxMessageCount: number,
     maxWaitTimeInSeconds?: number,
     maxMessageWaitTimeoutInSeconds?: number

--- a/test/maxDeliveryCount.spec.ts
+++ b/test/maxDeliveryCount.spec.ts
@@ -290,7 +290,7 @@ describe("Streaming Receiver: Message abandoned more than maxDeliveryCount goes 
     await delay(4000);
 
     await receiveListener.stop();
-    chai.assert.fail(unexpectedError && unexpectedError.message);
+    should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
 
     should.equal(checkDeliveryCount0, maxDeliveryCount);
     should.equal(checkDeliveryCount1, maxDeliveryCount);

--- a/test/streamingReceiver.spec.ts
+++ b/test/streamingReceiver.spec.ts
@@ -189,7 +189,7 @@ describe("Streaming Receiver Misc Tests", function(): void {
 
     await receiveListener.stop();
 
-    chai.assert.fail(unexpectedError && unexpectedError.message);
+    should.equal(unexpectedError, undefined, unexpectedError!.message);
 
     await testPeekMsgsLength(receiverClient, 0);
   }
@@ -248,7 +248,7 @@ describe("Streaming Receiver Misc Tests", function(): void {
     await receivedMsgs[1].complete();
     await receiveListener.stop();
 
-    chai.assert.fail(unexpectedError && unexpectedError.message);
+    should.equal(unexpectedError, undefined, unexpectedError!.message);
   }
 
   it("Disabled autoComplete, no manual complete retains the message in Partitioned Queues", async function(): Promise<
@@ -315,7 +315,7 @@ describe("Complete message", function(): void {
     }
 
     await receiveListener.stop();
-    chai.assert.fail(unexpectedError && unexpectedError.message);
+    should.equal(unexpectedError, undefined, unexpectedError!.message);
 
     await testPeekMsgsLength(receiverClient, 0);
   }
@@ -390,7 +390,7 @@ describe("Abandon message", function(): void {
     );
     await delay(4000);
 
-    chai.assert.fail(unexpectedError && unexpectedError.message);
+    should.equal(unexpectedError, undefined, unexpectedError!.message);
 
     const receivedMsgs = await receiverClient.receiveBatch(1);
     should.equal(receivedMsgs.length, 1);
@@ -482,7 +482,7 @@ describe("Defer message", function(): void {
     await delay(4000);
 
     await receiveListener.stop();
-    chai.assert.fail(unexpectedError && unexpectedError.message);
+    should.equal(unexpectedError, undefined, unexpectedError!.message);
 
     const deferredMsg0 = await receiverClient.receiveDeferredMessage(seq0);
     const deferredMsg1 = await receiverClient.receiveDeferredMessage(seq1);
@@ -578,7 +578,7 @@ describe("Deadletter message", function(): void {
 
     await delay(4000);
     await receiveListener.stop();
-    chai.assert.fail(unexpectedError && unexpectedError.message);
+    should.equal(unexpectedError, undefined, unexpectedError!.message);
 
     await testPeekMsgsLength(receiverClient, 0);
 
@@ -773,7 +773,7 @@ describe("Settle an already Settled message throws error", () => {
     }, unExpectedErrorHandler);
 
     await delay(5000);
-    chai.assert.fail(unexpectedError && unexpectedError.message);
+    should.equal(unexpectedError, undefined, unexpectedError!.message);
 
     should.equal(receivedMsgs.length, 1);
     should.equal(receivedMsgs[0].body, testMessages[0].body);


### PR DESCRIPTION
## Description

This PR fixes 2 kinds of failing tests

- The ones in maxDeliveryCount.spec.ts were failing due to the `chai.assert.fail` that would fail all the time. Replaced this with a `should` check
- Updated receiveBatch() function in the messageSession.ts file to be async. This fixes the failures of "Throws error when ReceiveBatch is called while the previous call is not done" test cases for sessions as mentioned in https://github.com/Azure/azure-service-bus-node/pull/211#issuecomment-455451970