### PR TITLE
Receive deferred messages tests

### DIFF
--- a/lib/subscriptionClient.ts
+++ b/lib/subscriptionClient.ts
@@ -266,16 +266,15 @@ export class SubscriptionClient extends Client {
     }
     return this._context.managementClient!.receiveDeferredMessage(sequenceNumber, this.receiveMode);
   }
-
   /**
    * Receives a list of deferred messages identified by `sequenceNumbers`.
    * @param sequenceNumbers A list containing the sequence numbers to receive.
-   * @returns Promise<ReceivedSBMessage[]>
+   * @returns Promise<ServiceBusMessage[]>
    * - Returns a list of messages identified by the given sequenceNumbers.
    * - Returns an empty list if no messages are found.
    * - Throws an error if the messages have not been deferred.
    */
-  async receiveDeferredMessages(sequenceNumbers: Long[]): Promise<ReceivedMessageInfo[]> {
+  async receiveDeferredMessages(sequenceNumbers: Long[]): Promise<ServiceBusMessage[]> {
     if (this.receiveMode !== ReceiveMode.peekLock) {
       throw new Error("The operation is only supported in 'PeekLock' receive mode.");
     }

--- a/lib/subscriptionClient.ts
+++ b/lib/subscriptionClient.ts
@@ -266,6 +266,7 @@ export class SubscriptionClient extends Client {
     }
     return this._context.managementClient!.receiveDeferredMessage(sequenceNumber, this.receiveMode);
   }
+
   /**
    * Receives a list of deferred messages identified by `sequenceNumbers`.
    * @param sequenceNumbers A list containing the sequence numbers to receive.


### PR DESCRIPTION
## Description
Found a bug related to `receiveDeferredMessages` module(in [subscriptionClient.ts](https://github.com/Azure/azure-service-bus-node/blob/master/lib/subscriptionClient.ts#L278)) while testing with streamingReceiver(#210).

```typescript
  /**
   * Receives a list of deferred messages identified by `sequenceNumbers`.
   * @param sequenceNumbers A list containing the sequence numbers to receive.
   * @returns Promise<ReceivedSBMessage[]>
   * - Returns a list of messages identified by the given sequenceNumbers.
   * - Returns an empty list if no messages are found.
   * - Throws an error if the messages have not been deferred.
   */
  async receiveDeferredMessages(sequenceNumbers: Long[]): Promise<ReceivedMessageInfo[]> {
    if (this.receiveMode !== ReceiveMode.peekLock) {
      throw new Error("The operation is only supported in 'PeekLock' receive mode.");
    }
    return this._context.managementClient!.receiveDeferredMessages(
      sequenceNumbers,
      this.receiveMode
    );
  }
```
Updated the return_type[**Promise<ReceivedMessageInfo[]>**] to the data type of actual returned value[**Promise<ServiceBusMessage[]>**].
```typescript
  /**
   * Receives a list of deferred messages identified by `sequenceNumbers`.
   * @param sequenceNumbers A list containing the sequence numbers to receive.
   * @returns Promise<ServiceBusMessage[]>
   * - Returns a list of messages identified by the given sequenceNumbers.
   * - Returns an empty list if no messages are found.
   * - Throws an error if the messages have not been deferred.
   */
  async receiveDeferredMessages(sequenceNumbers: Long[]): Promise<ServiceBusMessage[]> {
    if (this.receiveMode !== ReceiveMode.peekLock) {
      throw new Error("The operation is only supported in 'PeekLock' receive mode.");
    }
    return this._context.managementClient!.receiveDeferredMessages(
      sequenceNumbers,
      this.receiveMode
    );
  }
```

# Reference to any github issues
- #210 

@ramya-rao-a 
